### PR TITLE
feat: add review_session_summary table (v5 migration)

### DIFF
--- a/lib/core/database/database_constants.dart
+++ b/lib/core/database/database_constants.dart
@@ -1,12 +1,13 @@
 /// Compile-time constants for the SQLite schema.
 abstract final class DatabaseConstants {
   static const String databaseName = 'lapse.db';
-  static const int databaseVersion = 4;
+  static const int databaseVersion = 5;
 
   // -- Table names --
   static const String tableDecks = 'decks';
   static const String tableCards = 'cards';
   static const String tableReviews = 'reviews';
+  static const String tableReviewSessionSummary = 'review_session_summary';
 
   // -- Deck columns --
   static const String colDeckId = 'deck_id';
@@ -33,6 +34,21 @@ abstract final class DatabaseConstants {
   static const String colReviewedAt = 'reviewed_at';
   static const String colRating = 'rating';
   static const String colState = 'state';
+
+  // -- Review session summary columns --
+  static const String colSessionId = 'id';
+  static const String colDate = 'date';
+  static const String colStartedAt = 'started_at';
+  static const String colEndedAt = 'ended_at';
+  static const String colTotalReviews = 'total_reviews';
+  static const String colAgainCount = 'again_count';
+  static const String colHardCount = 'hard_count';
+  static const String colGoodCount = 'good_count';
+  static const String colEasyCount = 'easy_count';
+  static const String colNewCount = 'new_count';
+  static const String colLearningCount = 'learning_count';
+  static const String colReviewCount = 'review_count';
+  static const String colDurationMs = 'duration_ms';
 
   // -- Shared columns --
   static const String colCreatedAt = 'created_at';
@@ -97,6 +113,28 @@ abstract final class DatabaseConstants {
     )
   ''';
 
+  static const String createReviewSessionSummaryTable =
+      '''
+    CREATE TABLE $tableReviewSessionSummary (
+      $colSessionId       TEXT PRIMARY KEY,
+      $colUserId          TEXT NOT NULL DEFAULT '',
+      $colDate            TEXT NOT NULL,
+      $colStartedAt       TEXT NOT NULL,
+      $colEndedAt         TEXT NOT NULL,
+      $colTotalReviews    INTEGER NOT NULL DEFAULT 0,
+      $colAgainCount      INTEGER NOT NULL DEFAULT 0,
+      $colHardCount       INTEGER NOT NULL DEFAULT 0,
+      $colGoodCount       INTEGER NOT NULL DEFAULT 0,
+      $colEasyCount       INTEGER NOT NULL DEFAULT 0,
+      $colNewCount        INTEGER NOT NULL DEFAULT 0,
+      $colLearningCount   INTEGER NOT NULL DEFAULT 0,
+      $colReviewCount     INTEGER NOT NULL DEFAULT 0,
+      $colDurationMs      INTEGER NOT NULL DEFAULT 0,
+      $colSyncStatus      TEXT NOT NULL DEFAULT 'synced',
+      $colUpdatedAt       TEXT NOT NULL
+    )
+  ''';
+
   // ── CREATE INDEX DDL ──────────────────────────────────────────────
 
   static const String createIndexDecksParentId =
@@ -151,11 +189,28 @@ abstract final class DatabaseConstants {
       WHERE $colSyncStatus != 'synced'
   ''';
 
+  static const String createIndexSessionSummaryUserId =
+      '''
+    CREATE INDEX idx_session_summary_user_id ON $tableReviewSessionSummary($colUserId)
+  ''';
+
+  static const String createIndexSessionSummaryUserDate =
+      '''
+    CREATE INDEX idx_session_summary_user_date ON $tableReviewSessionSummary($colUserId, $colDate)
+  ''';
+
+  static const String createIndexSessionSummarySyncStatus =
+      '''
+    CREATE INDEX idx_session_summary_sync_status ON $tableReviewSessionSummary($colSyncStatus)
+      WHERE $colSyncStatus != 'synced'
+  ''';
+
   /// All DDL statements executed during [onCreate], in order.
   static const List<String> createStatements = [
     createDecksTable,
     createCardsTable,
     createReviewsTable,
+    createReviewSessionSummaryTable,
     createIndexDecksParentId,
     createIndexDecksUserId,
     createIndexCardsDueDate,
@@ -165,5 +220,8 @@ abstract final class DatabaseConstants {
     createIndexDecksSyncStatus,
     createIndexCardsSyncStatus,
     createIndexReviewsSyncStatus,
+    createIndexSessionSummaryUserId,
+    createIndexSessionSummaryUserDate,
+    createIndexSessionSummarySyncStatus,
   ];
 }

--- a/lib/core/database/database_helper.dart
+++ b/lib/core/database/database_helper.dart
@@ -86,6 +86,9 @@ class DatabaseHelper {
         case 4:
           await _migrateV4(db);
           break;
+        case 5:
+          await _migrateV5(db);
+          break;
         default:
           break;
       }
@@ -186,11 +189,20 @@ class DatabaseHelper {
     await db.execute(DatabaseConstants.createIndexReviewsSyncStatus);
   }
 
+  /// v5: Add review_session_summary table for persistent session tracking.
+  Future<void> _migrateV5(Database db) async {
+    await db.execute(DatabaseConstants.createReviewSessionSummaryTable);
+    await db.execute(DatabaseConstants.createIndexSessionSummaryUserId);
+    await db.execute(DatabaseConstants.createIndexSessionSummaryUserDate);
+    await db.execute(DatabaseConstants.createIndexSessionSummarySyncStatus);
+  }
+
   /// Deletes all rows from every table, preserving the schema.
   Future<void> clearAllData() async {
     final db = await database;
     await db.transaction((txn) async {
       await txn.delete(DatabaseConstants.tableReviews);
+      await txn.delete(DatabaseConstants.tableReviewSessionSummary);
       await txn.delete(DatabaseConstants.tableCards);
       await txn.delete(DatabaseConstants.tableDecks);
     });

--- a/lib/features/study/data/review_session_summary_repository.dart
+++ b/lib/features/study/data/review_session_summary_repository.dart
@@ -1,0 +1,83 @@
+import 'package:lapse/core/database/database_helper.dart';
+import 'package:lapse/core/database/database_constants.dart';
+import 'package:lapse/features/study/domain/review_session_summary.dart';
+
+class ReviewSessionSummaryRepository {
+  final DatabaseHelper _dbHelper;
+
+  ReviewSessionSummaryRepository({DatabaseHelper? dbHelper})
+      : _dbHelper = dbHelper ?? DatabaseHelper.instance;
+
+  /// Persists a completed session summary.
+  Future<void> add(ReviewSessionSummary summary) async {
+    final db = await _dbHelper.database;
+    await db.insert(
+      DatabaseConstants.tableReviewSessionSummary,
+      summary.toMap(),
+    );
+  }
+
+  /// Returns all session summaries for a given date (YYYY-MM-DD).
+  Future<List<ReviewSessionSummary>> getByDate(String date) async {
+    final db = await _dbHelper.database;
+    final maps = await db.query(
+      DatabaseConstants.tableReviewSessionSummary,
+      where: '${DatabaseConstants.colDate} = ?',
+      whereArgs: [date],
+      orderBy: '${DatabaseConstants.colStartedAt} ASC',
+    );
+    return maps.map(ReviewSessionSummary.fromMap).toList();
+  }
+
+  /// Returns all session summaries within a date range (inclusive).
+  Future<List<ReviewSessionSummary>> getByDateRange(
+    String startDate,
+    String endDate,
+  ) async {
+    final db = await _dbHelper.database;
+    final maps = await db.query(
+      DatabaseConstants.tableReviewSessionSummary,
+      where: '${DatabaseConstants.colDate} >= ? AND ${DatabaseConstants.colDate} <= ?',
+      whereArgs: [startDate, endDate],
+      orderBy: '${DatabaseConstants.colStartedAt} ASC',
+    );
+    return maps.map(ReviewSessionSummary.fromMap).toList();
+  }
+
+  /// Returns all session summaries, ordered by most recent first.
+  Future<List<ReviewSessionSummary>> getAll() async {
+    final db = await _dbHelper.database;
+    final maps = await db.query(
+      DatabaseConstants.tableReviewSessionSummary,
+      orderBy: '${DatabaseConstants.colStartedAt} DESC',
+    );
+    return maps.map(ReviewSessionSummary.fromMap).toList();
+  }
+
+  /// Returns aggregate daily stats: total reviews, duration, and rating
+  /// breakdown for each date in the range. Uses SQL aggregation to avoid
+  /// pulling full rows into Dart.
+  Future<List<Map<String, dynamic>>> getDailyStats(
+    String startDate,
+    String endDate,
+  ) async {
+    final db = await _dbHelper.database;
+    return db.rawQuery('''
+      SELECT
+        ${DatabaseConstants.colDate},
+        SUM(${DatabaseConstants.colTotalReviews}) AS ${DatabaseConstants.colTotalReviews},
+        SUM(${DatabaseConstants.colAgainCount}) AS ${DatabaseConstants.colAgainCount},
+        SUM(${DatabaseConstants.colHardCount}) AS ${DatabaseConstants.colHardCount},
+        SUM(${DatabaseConstants.colGoodCount}) AS ${DatabaseConstants.colGoodCount},
+        SUM(${DatabaseConstants.colEasyCount}) AS ${DatabaseConstants.colEasyCount},
+        SUM(${DatabaseConstants.colNewCount}) AS ${DatabaseConstants.colNewCount},
+        SUM(${DatabaseConstants.colLearningCount}) AS ${DatabaseConstants.colLearningCount},
+        SUM(${DatabaseConstants.colReviewCount}) AS ${DatabaseConstants.colReviewCount},
+        SUM(${DatabaseConstants.colDurationMs}) AS ${DatabaseConstants.colDurationMs}
+      FROM ${DatabaseConstants.tableReviewSessionSummary}
+      WHERE ${DatabaseConstants.colDate} >= ? AND ${DatabaseConstants.colDate} <= ?
+      GROUP BY ${DatabaseConstants.colDate}
+      ORDER BY ${DatabaseConstants.colDate} ASC
+    ''', [startDate, endDate]);
+  }
+}

--- a/lib/features/study/domain/review_session_summary.dart
+++ b/lib/features/study/domain/review_session_summary.dart
@@ -1,0 +1,182 @@
+import 'package:equatable/equatable.dart';
+import 'package:lapse/core/database/database_constants.dart';
+import 'package:lapse/core/domain/sync_status.dart';
+import 'package:uuid/uuid.dart';
+
+/// A persisted summary of a single study session.
+///
+/// One row per session (not per day). Aggregated when the session ends.
+/// Powers historical stats UI: heatmaps, streaks, rating trends, time-studied.
+class ReviewSessionSummary extends Equatable {
+  final String id;
+  final String userId;
+  final String date; // YYYY-MM-DD for fast daily grouping
+  final DateTime startedAt;
+  final DateTime endedAt;
+  final int totalReviews;
+  final int againCount;
+  final int hardCount;
+  final int goodCount;
+  final int easyCount;
+  final int newCount; // cards in new state when reviewed
+  final int learningCount; // cards in learning/relearning state
+  final int reviewCount; // cards in review state
+  final int durationMs;
+  final SyncStatus syncStatus;
+  final DateTime updatedAt;
+
+  static const _uuid = Uuid();
+
+  ReviewSessionSummary({
+    String? id,
+    this.userId = '',
+    required this.date,
+    required this.startedAt,
+    required this.endedAt,
+    this.totalReviews = 0,
+    this.againCount = 0,
+    this.hardCount = 0,
+    this.goodCount = 0,
+    this.easyCount = 0,
+    this.newCount = 0,
+    this.learningCount = 0,
+    this.reviewCount = 0,
+    this.durationMs = 0,
+    this.syncStatus = SyncStatus.synced,
+    DateTime? updatedAt,
+  })  : id = id ?? _uuid.v4(),
+        updatedAt = updatedAt ?? DateTime.now();
+
+  /// Creates a summary from a completed study session.
+  factory ReviewSessionSummary.fromSession({
+    required DateTime startedAt,
+    required DateTime endedAt,
+    required int againCount,
+    required int hardCount,
+    required int goodCount,
+    required int easyCount,
+    required int newCount,
+    required int learningCount,
+    required int reviewCount,
+    String userId = '',
+  }) {
+    final date =
+        '${startedAt.year}-${startedAt.month.toString().padLeft(2, '0')}-${startedAt.day.toString().padLeft(2, '0')}';
+    return ReviewSessionSummary(
+      userId: userId,
+      date: date,
+      startedAt: startedAt,
+      endedAt: endedAt,
+      totalReviews: againCount + hardCount + goodCount + easyCount,
+      againCount: againCount,
+      hardCount: hardCount,
+      goodCount: goodCount,
+      easyCount: easyCount,
+      newCount: newCount,
+      learningCount: learningCount,
+      reviewCount: reviewCount,
+      durationMs: endedAt.difference(startedAt).inMilliseconds,
+    );
+  }
+
+  ReviewSessionSummary copyWith({
+    String? userId,
+    String? date,
+    DateTime? startedAt,
+    DateTime? endedAt,
+    int? totalReviews,
+    int? againCount,
+    int? hardCount,
+    int? goodCount,
+    int? easyCount,
+    int? newCount,
+    int? learningCount,
+    int? reviewCount,
+    int? durationMs,
+    SyncStatus? syncStatus,
+    DateTime? updatedAt,
+  }) {
+    return ReviewSessionSummary(
+      id: id,
+      userId: userId ?? this.userId,
+      date: date ?? this.date,
+      startedAt: startedAt ?? this.startedAt,
+      endedAt: endedAt ?? this.endedAt,
+      totalReviews: totalReviews ?? this.totalReviews,
+      againCount: againCount ?? this.againCount,
+      hardCount: hardCount ?? this.hardCount,
+      goodCount: goodCount ?? this.goodCount,
+      easyCount: easyCount ?? this.easyCount,
+      newCount: newCount ?? this.newCount,
+      learningCount: learningCount ?? this.learningCount,
+      reviewCount: reviewCount ?? this.reviewCount,
+      durationMs: durationMs ?? this.durationMs,
+      syncStatus: syncStatus ?? this.syncStatus,
+      updatedAt: updatedAt ?? this.updatedAt,
+    );
+  }
+
+  Map<String, dynamic> toMap() {
+    return {
+      DatabaseConstants.colSessionId: id,
+      DatabaseConstants.colUserId: userId,
+      DatabaseConstants.colDate: date,
+      DatabaseConstants.colStartedAt: startedAt.toIso8601String(),
+      DatabaseConstants.colEndedAt: endedAt.toIso8601String(),
+      DatabaseConstants.colTotalReviews: totalReviews,
+      DatabaseConstants.colAgainCount: againCount,
+      DatabaseConstants.colHardCount: hardCount,
+      DatabaseConstants.colGoodCount: goodCount,
+      DatabaseConstants.colEasyCount: easyCount,
+      DatabaseConstants.colNewCount: newCount,
+      DatabaseConstants.colLearningCount: learningCount,
+      DatabaseConstants.colReviewCount: reviewCount,
+      DatabaseConstants.colDurationMs: durationMs,
+      DatabaseConstants.colSyncStatus: syncStatus.name,
+      DatabaseConstants.colUpdatedAt: updatedAt.toIso8601String(),
+    };
+  }
+
+  factory ReviewSessionSummary.fromMap(Map<String, dynamic> map) {
+    return ReviewSessionSummary(
+      id: map[DatabaseConstants.colSessionId] as String,
+      userId: map[DatabaseConstants.colUserId] as String? ?? '',
+      date: map[DatabaseConstants.colDate] as String,
+      startedAt: DateTime.parse(map[DatabaseConstants.colStartedAt] as String),
+      endedAt: DateTime.parse(map[DatabaseConstants.colEndedAt] as String),
+      totalReviews: map[DatabaseConstants.colTotalReviews] as int,
+      againCount: map[DatabaseConstants.colAgainCount] as int,
+      hardCount: map[DatabaseConstants.colHardCount] as int,
+      goodCount: map[DatabaseConstants.colGoodCount] as int,
+      easyCount: map[DatabaseConstants.colEasyCount] as int,
+      newCount: map[DatabaseConstants.colNewCount] as int,
+      learningCount: map[DatabaseConstants.colLearningCount] as int,
+      reviewCount: map[DatabaseConstants.colReviewCount] as int,
+      durationMs: map[DatabaseConstants.colDurationMs] as int,
+      syncStatus: SyncStatus.values.byName(
+        map[DatabaseConstants.colSyncStatus] as String,
+      ),
+      updatedAt: DateTime.parse(map[DatabaseConstants.colUpdatedAt] as String),
+    );
+  }
+
+  @override
+  List<Object?> get props => [
+        id,
+        userId,
+        date,
+        startedAt,
+        endedAt,
+        totalReviews,
+        againCount,
+        hardCount,
+        goodCount,
+        easyCount,
+        newCount,
+        learningCount,
+        reviewCount,
+        durationMs,
+        syncStatus,
+        updatedAt,
+      ];
+}


### PR DESCRIPTION
## Summary
- Adds `review_session_summary` SQLite table via v5 migration for persistent study session tracking
- Creates `ReviewSessionSummary` domain model with `fromSession()` factory, `toMap()`/`fromMap()`, and Equatable support
- Creates `ReviewSessionSummaryRepository` with CRUD + `getDailyStats()` SQL aggregation for future stats UI (heatmaps, streaks, rating trends)
- Updates `DatabaseConstants` with table name, 13 column constants, CREATE TABLE DDL, and 3 indexes (`user_id`, `(user_id, date)` composite, `sync_status` partial)
- Updates `DatabaseHelper` with `_migrateV5` and includes new table in `clearAllData()`

Part of sync schema plan — Phase 1.5 (#133).