### PR TITLE
feat: add supabase postgres schema, RLS, and privilege hardening

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,18 @@
 - **Supabase project config is our responsibility** — email confirmation, OTP expiry, CAPTCHA, custom SMTP. These are dashboard settings but must be enabled before production.
 - **The anon key ships in the app binary** (publicly visible). RLS + privilege revocation are the real security layer, not key secrecy.
 
+### Supabase Migration & Schema Guidelines
+
+- **Wrap migrations in `BEGIN; ... COMMIT;`** — Supabase CLI does NOT auto-wrap migrations in transactions. A partial failure leaves the schema in a broken state without explicit transaction wrapping.
+- **RLS policies: always use `(select auth.uid())`** — wrap in a subquery, never bare `auth.uid()`. The subquery lets Postgres cache the result per-statement instead of calling it per-row (benchmarked 94-99% improvement).
+- **RLS policies: always specify `TO authenticated`** — without it, the policy evaluates for all roles including `anon`, wasting cycles (benchmarked 99.78% improvement).
+- **Privilege pattern: REVOKE ALL → explicit GRANT** — never rely on Supabase's default broad grants. Revoke everything from both `anon` and `authenticated`, then grant back only the exact operations needed. This future-proofs against default changes.
+- **Index columns used in RLS policies** — any column referenced in a `USING` or `WITH CHECK` clause (e.g., `user_id`) must be indexed, or every policy check triggers a sequential scan.
+- **Use custom PL/pgSQL for `updated_at` triggers** — don't use the `moddatetime` extension (docs 404, potential deprecation risk). A simple `set_updated_at()` function has zero dependency.
+- **Install extensions in `extensions` schema** — never in `public`. Supabase's `extra_search_path` includes `extensions` by default.
+- **Views bypass RLS by default** — they run as the `postgres` owner. If we add views, use `security_invoker = true` (Postgres 15+).
+- **`config.toml` is for local dev only** — production auth settings (SMTP, CAPTCHA, password requirements) are managed via the Supabase dashboard or `supabase config push`.
+
 ---
 
 ## Future Work & Design Decisions

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -1,0 +1,388 @@
+# For detailed configuration reference documentation, visit:
+# https://supabase.com/docs/guides/local-development/cli/config
+# A string used to distinguish different Supabase projects on the same host. Defaults to the
+# working directory name when running `supabase init`.
+project_id = "lapse"
+
+[api]
+enabled = true
+# Port to use for the API URL.
+port = 54321
+# Schemas to expose in your API. Tables, views and stored procedures in this schema will get API
+# endpoints. `public` and `graphql_public` schemas are included by default.
+schemas = ["public", "graphql_public"]
+# Extra schemas to add to the search_path of every request.
+extra_search_path = ["public", "extensions"]
+# The maximum number of rows returns from a view, table, or stored procedure. Limits payload size
+# for accidental or malicious requests.
+max_rows = 1000
+
+[api.tls]
+# Enable HTTPS endpoints locally using a self-signed certificate.
+enabled = false
+# Paths to self-signed certificate pair.
+# cert_path = "../certs/my-cert.pem"
+# key_path = "../certs/my-key.pem"
+
+[db]
+# Port to use for the local database URL.
+port = 54322
+# Port used by db diff command to initialize the shadow database.
+shadow_port = 54320
+# Maximum amount of time to wait for health check when starting the local database.
+health_timeout = "2m"
+# The database major version to use. This has to be the same as your remote database's. Run `SHOW
+# server_version;` on the remote database to check.
+major_version = 17
+
+[db.pooler]
+enabled = false
+# Port to use for the local connection pooler.
+port = 54329
+# Specifies when a server connection can be reused by other clients.
+# Configure one of the supported pooler modes: `transaction`, `session`.
+pool_mode = "transaction"
+# How many server connections to allow per user/database pair.
+default_pool_size = 20
+# Maximum number of client connections allowed.
+max_client_conn = 100
+
+# [db.vault]
+# secret_key = "env(SECRET_VALUE)"
+
+[db.migrations]
+# If disabled, migrations will be skipped during a db push or reset.
+enabled = true
+# Specifies an ordered list of schema files that describe your database.
+# Supports glob patterns relative to supabase directory: "./schemas/*.sql"
+schema_paths = []
+
+[db.seed]
+# If enabled, seeds the database after migrations during a db reset.
+enabled = true
+# Specifies an ordered list of seed files to load during db reset.
+# Supports glob patterns relative to supabase directory: "./seeds/*.sql"
+sql_paths = ["./seed.sql"]
+
+[db.network_restrictions]
+# Enable management of network restrictions.
+enabled = false
+# List of IPv4 CIDR blocks allowed to connect to the database.
+# Defaults to allow all IPv4 connections. Set empty array to block all IPs.
+allowed_cidrs = ["0.0.0.0/0"]
+# List of IPv6 CIDR blocks allowed to connect to the database.
+# Defaults to allow all IPv6 connections. Set empty array to block all IPs.
+allowed_cidrs_v6 = ["::/0"]
+
+# Uncomment to reject non-secure connections to the database.
+# [db.ssl_enforcement]
+# enabled = true
+
+[realtime]
+enabled = true
+# Bind realtime via either IPv4 or IPv6. (default: IPv4)
+# ip_version = "IPv6"
+# The maximum length in bytes of HTTP request headers. (default: 4096)
+# max_header_length = 4096
+
+[studio]
+enabled = true
+# Port to use for Supabase Studio.
+port = 54323
+# External URL of the API server that frontend connects to.
+api_url = "http://127.0.0.1"
+# OpenAI API Key to use for Supabase AI in the Supabase Studio.
+openai_api_key = "env(OPENAI_API_KEY)"
+
+# Email testing server. Emails sent with the local dev setup are not actually sent - rather, they
+# are monitored, and you can view the emails that would have been sent from the web interface.
+[inbucket]
+enabled = true
+# Port to use for the email testing server web interface.
+port = 54324
+# Uncomment to expose additional ports for testing user applications that send emails.
+# smtp_port = 54325
+# pop3_port = 54326
+# admin_email = "admin@email.com"
+# sender_name = "Admin"
+
+[storage]
+enabled = true
+# The maximum file size allowed (e.g. "5MB", "500KB").
+file_size_limit = "50MiB"
+
+# Uncomment to configure local storage buckets
+# [storage.buckets.images]
+# public = false
+# file_size_limit = "50MiB"
+# allowed_mime_types = ["image/png", "image/jpeg"]
+# objects_path = "./images"
+
+# Allow connections via S3 compatible clients
+[storage.s3_protocol]
+enabled = true
+
+# Image transformation API is available to Supabase Pro plan.
+# [storage.image_transformation]
+# enabled = true
+
+# Store analytical data in S3 for running ETL jobs over Iceberg Catalog
+# This feature is only available on the hosted platform.
+[storage.analytics]
+enabled = false
+max_namespaces = 5
+max_tables = 10
+max_catalogs = 2
+
+# Analytics Buckets is available to Supabase Pro plan.
+# [storage.analytics.buckets.my-warehouse]
+
+# Store vector embeddings in S3 for large and durable datasets
+# This feature is only available on the hosted platform.
+[storage.vector]
+enabled = false
+max_buckets = 10
+max_indexes = 5
+
+# Vector Buckets is available to Supabase Pro plan.
+# [storage.vector.buckets.documents-openai]
+
+[auth]
+enabled = true
+# The base URL of your website. Used as an allow-list for redirects and for constructing URLs used
+# in emails.
+site_url = "http://127.0.0.1:3000"
+# A list of *exact* URLs that auth providers are permitted to redirect to post authentication.
+additional_redirect_urls = ["https://127.0.0.1:3000"]
+# How long tokens are valid for, in seconds. Defaults to 3600 (1 hour), maximum 604,800 (1 week).
+jwt_expiry = 3600
+# JWT issuer URL. If not set, defaults to the local API URL (http://127.0.0.1:<port>/auth/v1).
+# jwt_issuer = ""
+# Path to JWT signing key. DO NOT commit your signing keys file to git.
+# signing_keys_path = "./signing_keys.json"
+# If disabled, the refresh token will never expire.
+enable_refresh_token_rotation = true
+# Allows refresh tokens to be reused after expiry, up to the specified interval in seconds.
+# Requires enable_refresh_token_rotation = true.
+refresh_token_reuse_interval = 10
+# Allow/disallow new user signups to your project.
+enable_signup = true
+# Allow/disallow anonymous sign-ins to your project.
+enable_anonymous_sign_ins = false
+# Allow/disallow testing manual linking of accounts
+enable_manual_linking = false
+# Passwords shorter than this value will be rejected as weak. Minimum 6, recommended 8 or more.
+minimum_password_length = 6
+# Passwords that do not meet the following requirements will be rejected as weak. Supported values
+# are: `letters_digits`, `lower_upper_letters_digits`, `lower_upper_letters_digits_symbols`
+password_requirements = ""
+
+[auth.rate_limit]
+# Number of emails that can be sent per hour. Requires auth.email.smtp to be enabled.
+email_sent = 2
+# Number of SMS messages that can be sent per hour. Requires auth.sms to be enabled.
+sms_sent = 30
+# Number of anonymous sign-ins that can be made per hour per IP address. Requires enable_anonymous_sign_ins = true.
+anonymous_users = 30
+# Number of sessions that can be refreshed in a 5 minute interval per IP address.
+token_refresh = 150
+# Number of sign up and sign-in requests that can be made in a 5 minute interval per IP address (excludes anonymous users).
+sign_in_sign_ups = 30
+# Number of OTP / Magic link verifications that can be made in a 5 minute interval per IP address.
+token_verifications = 30
+# Number of Web3 logins that can be made in a 5 minute interval per IP address.
+web3 = 30
+
+# Configure one of the supported captcha providers: `hcaptcha`, `turnstile`.
+# [auth.captcha]
+# enabled = true
+# provider = "hcaptcha"
+# secret = ""
+
+[auth.email]
+# Allow/disallow new user signups via email to your project.
+enable_signup = true
+# If enabled, a user will be required to confirm any email change on both the old, and new email
+# addresses. If disabled, only the new email is required to confirm.
+double_confirm_changes = true
+# If enabled, users need to confirm their email address before signing in.
+enable_confirmations = false
+# If enabled, users will need to reauthenticate or have logged in recently to change their password.
+secure_password_change = false
+# Controls the minimum amount of time that must pass before sending another signup confirmation or password reset email.
+max_frequency = "1s"
+# Number of characters used in the email OTP.
+otp_length = 6
+# Number of seconds before the email OTP expires (defaults to 1 hour).
+otp_expiry = 3600
+
+# Use a production-ready SMTP server
+# [auth.email.smtp]
+# enabled = true
+# host = "smtp.sendgrid.net"
+# port = 587
+# user = "apikey"
+# pass = "env(SENDGRID_API_KEY)"
+# admin_email = "admin@email.com"
+# sender_name = "Admin"
+
+# Uncomment to customize email template
+# [auth.email.template.invite]
+# subject = "You have been invited"
+# content_path = "./supabase/templates/invite.html"
+
+# Uncomment to customize notification email template
+# [auth.email.notification.password_changed]
+# enabled = true
+# subject = "Your password has been changed"
+# content_path = "./templates/password_changed_notification.html"
+
+[auth.sms]
+# Allow/disallow new user signups via SMS to your project.
+enable_signup = false
+# If enabled, users need to confirm their phone number before signing in.
+enable_confirmations = false
+# Template for sending OTP to users
+template = "Your code is {{ .Code }}"
+# Controls the minimum amount of time that must pass before sending another sms otp.
+max_frequency = "5s"
+
+# Use pre-defined map of phone number to OTP for testing.
+# [auth.sms.test_otp]
+# 4152127777 = "123456"
+
+# Configure logged in session timeouts.
+# [auth.sessions]
+# Force log out after the specified duration.
+# timebox = "24h"
+# Force log out if the user has been inactive longer than the specified duration.
+# inactivity_timeout = "8h"
+
+# This hook runs before a new user is created and allows developers to reject the request based on the incoming user object.
+# [auth.hook.before_user_created]
+# enabled = true
+# uri = "pg-functions://postgres/auth/before-user-created-hook"
+
+# This hook runs before a token is issued and allows you to add additional claims based on the authentication method used.
+# [auth.hook.custom_access_token]
+# enabled = true
+# uri = "pg-functions://<database>/<schema>/<hook_name>"
+
+# Configure one of the supported SMS providers: `twilio`, `twilio_verify`, `messagebird`, `textlocal`, `vonage`.
+[auth.sms.twilio]
+enabled = false
+account_sid = ""
+message_service_sid = ""
+# DO NOT commit your Twilio auth token to git. Use environment variable substitution instead:
+auth_token = "env(SUPABASE_AUTH_SMS_TWILIO_AUTH_TOKEN)"
+
+# Multi-factor-authentication is available to Supabase Pro plan.
+[auth.mfa]
+# Control how many MFA factors can be enrolled at once per user.
+max_enrolled_factors = 10
+
+# Control MFA via App Authenticator (TOTP)
+[auth.mfa.totp]
+enroll_enabled = false
+verify_enabled = false
+
+# Configure MFA via Phone Messaging
+[auth.mfa.phone]
+enroll_enabled = false
+verify_enabled = false
+otp_length = 6
+template = "Your code is {{ .Code }}"
+max_frequency = "5s"
+
+# Configure MFA via WebAuthn
+# [auth.mfa.web_authn]
+# enroll_enabled = true
+# verify_enabled = true
+
+# Use an external OAuth provider. The full list of providers are: `apple`, `azure`, `bitbucket`,
+# `discord`, `facebook`, `github`, `gitlab`, `google`, `keycloak`, `linkedin_oidc`, `notion`, `twitch`,
+# `twitter`, `x`, `slack`, `spotify`, `workos`, `zoom`.
+[auth.external.apple]
+enabled = false
+client_id = ""
+# DO NOT commit your OAuth provider secret to git. Use environment variable substitution instead:
+secret = "env(SUPABASE_AUTH_EXTERNAL_APPLE_SECRET)"
+# Overrides the default auth redirectUrl.
+redirect_uri = ""
+# Overrides the default auth provider URL. Used to support self-hosted gitlab, single-tenant Azure,
+# or any other third-party OIDC providers.
+url = ""
+# If enabled, the nonce check will be skipped. Required for local sign in with Google auth.
+skip_nonce_check = false
+# If enabled, it will allow the user to successfully authenticate when the provider does not return an email address.
+email_optional = false
+
+# Allow Solana wallet holders to sign in to your project via the Sign in with Solana (SIWS, EIP-4361) standard.
+# You can configure "web3" rate limit in the [auth.rate_limit] section and set up [auth.captcha] if self-hosting.
+[auth.web3.solana]
+enabled = false
+
+# Use Firebase Auth as a third-party provider alongside Supabase Auth.
+[auth.third_party.firebase]
+enabled = false
+# project_id = "my-firebase-project"
+
+# Use Auth0 as a third-party provider alongside Supabase Auth.
+[auth.third_party.auth0]
+enabled = false
+# tenant = "my-auth0-tenant"
+# tenant_region = "us"
+
+# Use AWS Cognito (Amplify) as a third-party provider alongside Supabase Auth.
+[auth.third_party.aws_cognito]
+enabled = false
+# user_pool_id = "my-user-pool-id"
+# user_pool_region = "us-east-1"
+
+# Use Clerk as a third-party provider alongside Supabase Auth.
+[auth.third_party.clerk]
+enabled = false
+# Obtain from https://clerk.com/setup/supabase
+# domain = "example.clerk.accounts.dev"
+
+# OAuth server configuration
+[auth.oauth_server]
+# Enable OAuth server functionality
+enabled = false
+# Path for OAuth consent flow UI
+authorization_url_path = "/oauth/consent"
+# Allow dynamic client registration
+allow_dynamic_registration = false
+
+[edge_runtime]
+enabled = true
+# Supported request policies: `oneshot`, `per_worker`.
+# `per_worker` (default) — enables hot reload during local development.
+# `oneshot` — fallback mode if hot reload causes issues (e.g. in large repos or with symlinks).
+policy = "per_worker"
+# Port to attach the Chrome inspector for debugging edge functions.
+inspector_port = 8083
+# The Deno major version to use.
+deno_version = 2
+
+# [edge_runtime.secrets]
+# secret_key = "env(SECRET_VALUE)"
+
+[analytics]
+enabled = true
+port = 54327
+# Configure one of the supported backends: `postgres`, `bigquery`.
+backend = "postgres"
+
+# Experimental features may be deprecated any time
+[experimental]
+# Configures Postgres storage engine to use OrioleDB (S3)
+orioledb_version = ""
+# Configures S3 bucket URL, eg. <bucket_name>.s3-<region>.amazonaws.com
+s3_host = "env(S3_HOST)"
+# Configures S3 bucket region, eg. us-east-1
+s3_region = "env(S3_REGION)"
+# Configures AWS_ACCESS_KEY_ID for S3 bucket
+s3_access_key = "env(S3_ACCESS_KEY)"
+# Configures AWS_SECRET_ACCESS_KEY for S3 bucket
+s3_secret_key = "env(S3_SECRET_KEY)"

--- a/supabase/migrations/20260314160644_create_schema.sql
+++ b/supabase/migrations/20260314160644_create_schema.sql
@@ -1,0 +1,253 @@
+-- Lapse: initial schema — tables, indexes, triggers, RLS, privileges
+-- All four tables in one atomic transaction.
+
+BEGIN;
+
+-- ══════════════════════════════════════════════════════════════════════
+-- TABLES
+-- ══════════════════════════════════════════════════════════════════════
+
+CREATE TABLE public.decks (
+  deck_id     uuid PRIMARY KEY,
+  parent_id   uuid REFERENCES public.decks(deck_id) ON DELETE CASCADE,
+  deck_name   text NOT NULL,
+  user_id     uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  created_at  timestamptz NOT NULL DEFAULT now(),
+  updated_at  timestamptz NOT NULL DEFAULT now(),
+  is_deleted  boolean NOT NULL DEFAULT false,
+  CONSTRAINT chk_deck_name_not_empty CHECK (deck_name != '')
+);
+
+CREATE TABLE public.cards (
+  card_id         uuid PRIMARY KEY,
+  deck_id         uuid NOT NULL REFERENCES public.decks(deck_id) ON DELETE CASCADE,
+  front           text NOT NULL,
+  back            text NOT NULL,
+  created_at      timestamptz NOT NULL DEFAULT now(),
+  updated_at      timestamptz NOT NULL DEFAULT now(),
+  is_deleted      boolean NOT NULL DEFAULT false,
+  due_date        timestamptz NOT NULL,
+  stability       double precision NOT NULL DEFAULT 0.0,
+  difficulty      double precision NOT NULL DEFAULT 0.0,
+  elapsed_days    integer NOT NULL DEFAULT 0,
+  scheduled_days  integer NOT NULL DEFAULT 0,
+  reps            integer NOT NULL DEFAULT 0,
+  lapses          integer NOT NULL DEFAULT 0,
+  last_review     timestamptz,
+  card_state      integer NOT NULL DEFAULT 0,
+  step            integer,
+  user_id         uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  CONSTRAINT chk_card_state CHECK (card_state BETWEEN 0 AND 3),
+  CONSTRAINT chk_front_not_empty CHECK (front != ''),
+  CONSTRAINT chk_back_not_empty CHECK (back != '')
+);
+
+CREATE TABLE public.reviews (
+  review_id       uuid PRIMARY KEY,
+  card_id         uuid NOT NULL REFERENCES public.cards(card_id) ON DELETE CASCADE,
+  reviewed_at     timestamptz NOT NULL,
+  rating          integer NOT NULL,
+  scheduled_days  integer NOT NULL,
+  elapsed_days    integer NOT NULL,
+  state           integer NOT NULL,
+  user_id         uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  CONSTRAINT chk_rating CHECK (rating BETWEEN 1 AND 4),
+  CONSTRAINT chk_review_state CHECK (state BETWEEN 0 AND 3)
+);
+
+CREATE TABLE public.review_session_summary (
+  id              uuid PRIMARY KEY,
+  user_id         uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  date            date NOT NULL,
+  started_at      timestamptz NOT NULL,
+  ended_at        timestamptz NOT NULL,
+  total_reviews   integer NOT NULL DEFAULT 0,
+  again_count     integer NOT NULL DEFAULT 0,
+  hard_count      integer NOT NULL DEFAULT 0,
+  good_count      integer NOT NULL DEFAULT 0,
+  easy_count      integer NOT NULL DEFAULT 0,
+  new_count       integer NOT NULL DEFAULT 0,
+  learning_count  integer NOT NULL DEFAULT 0,
+  review_count    integer NOT NULL DEFAULT 0,
+  duration_ms     integer NOT NULL DEFAULT 0,
+  updated_at      timestamptz NOT NULL DEFAULT now()
+);
+
+-- ══════════════════════════════════════════════════════════════════════
+-- INDEXES
+-- ══════════════════════════════════════════════════════════════════════
+
+-- Deck lookups
+CREATE INDEX idx_decks_parent_id ON public.decks(parent_id)
+  WHERE NOT is_deleted AND parent_id IS NOT NULL;
+CREATE INDEX idx_decks_user_id ON public.decks(user_id)
+  WHERE NOT is_deleted;
+
+-- Card lookups
+CREATE INDEX idx_cards_due_date ON public.cards(due_date)
+  WHERE NOT is_deleted;
+CREATE INDEX idx_cards_deck_due ON public.cards(deck_id, due_date)
+  WHERE NOT is_deleted;
+CREATE INDEX idx_cards_user_id ON public.cards(user_id)
+  WHERE NOT is_deleted;
+
+-- Review lookups
+CREATE INDEX idx_reviews_card_id ON public.reviews(card_id);
+CREATE INDEX idx_reviews_reviewed_at ON public.reviews(reviewed_at);
+CREATE INDEX idx_reviews_user_id ON public.reviews(user_id);
+
+-- Session summary lookups
+CREATE INDEX idx_session_summary_user_id ON public.review_session_summary(user_id);
+CREATE INDEX idx_session_summary_user_date ON public.review_session_summary(user_id, date);
+
+-- Sync pull indexes (fetch changes since last sync)
+CREATE INDEX idx_decks_user_updated ON public.decks(user_id, updated_at);
+CREATE INDEX idx_cards_user_updated ON public.cards(user_id, updated_at);
+CREATE INDEX idx_reviews_user_reviewed ON public.reviews(user_id, reviewed_at);
+CREATE INDEX idx_session_summary_user_updated ON public.review_session_summary(user_id, updated_at);
+
+-- ══════════════════════════════════════════════════════════════════════
+-- UPDATED_AT TRIGGER (custom function, no extension dependency)
+-- ══════════════════════════════════════════════════════════════════════
+
+CREATE OR REPLACE FUNCTION set_updated_at()
+RETURNS trigger AS $$
+BEGIN
+  new.updated_at = now();
+  RETURN new;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Reviews are immutable — no trigger needed
+CREATE TRIGGER handle_updated_at BEFORE UPDATE ON public.decks
+  FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+CREATE TRIGGER handle_updated_at BEFORE UPDATE ON public.cards
+  FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+CREATE TRIGGER handle_updated_at BEFORE UPDATE ON public.review_session_summary
+  FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+
+-- ══════════════════════════════════════════════════════════════════════
+-- ROW LEVEL SECURITY
+-- ══════════════════════════════════════════════════════════════════════
+
+ALTER TABLE public.decks ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.cards ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.reviews ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.review_session_summary ENABLE ROW LEVEL SECURITY;
+
+-- Decks: SELECT + INSERT + UPDATE (no client-side hard-delete)
+CREATE POLICY "Users can view their own decks"
+  ON public.decks FOR SELECT TO authenticated
+  USING ((select auth.uid()) = user_id);
+
+CREATE POLICY "Users can insert their own decks"
+  ON public.decks FOR INSERT TO authenticated
+  WITH CHECK (
+    (select auth.uid()) = user_id
+    AND (
+      parent_id IS NULL
+      OR EXISTS (
+        SELECT 1 FROM public.decks d
+        WHERE d.deck_id = parent_id
+          AND d.user_id = (select auth.uid())
+      )
+    )
+  );
+
+CREATE POLICY "Users can update their own decks"
+  ON public.decks FOR UPDATE TO authenticated
+  USING ((select auth.uid()) = user_id)
+  WITH CHECK (
+    (select auth.uid()) = user_id
+    AND (
+      parent_id IS NULL
+      OR EXISTS (
+        SELECT 1 FROM public.decks d
+        WHERE d.deck_id = parent_id
+          AND d.user_id = (select auth.uid())
+      )
+    )
+  );
+
+-- Cards: SELECT + INSERT + UPDATE (no client-side hard-delete)
+CREATE POLICY "Users can view their own cards"
+  ON public.cards FOR SELECT TO authenticated
+  USING ((select auth.uid()) = user_id);
+
+CREATE POLICY "Users can insert their own cards"
+  ON public.cards FOR INSERT TO authenticated
+  WITH CHECK (
+    (select auth.uid()) = user_id
+    AND EXISTS (
+      SELECT 1 FROM public.decks d
+      WHERE d.deck_id = cards.deck_id
+        AND d.user_id = (select auth.uid())
+    )
+  );
+
+CREATE POLICY "Users can update their own cards"
+  ON public.cards FOR UPDATE TO authenticated
+  USING ((select auth.uid()) = user_id)
+  WITH CHECK (
+    (select auth.uid()) = user_id
+    AND EXISTS (
+      SELECT 1 FROM public.decks d
+      WHERE d.deck_id = cards.deck_id
+        AND d.user_id = (select auth.uid())
+    )
+  );
+
+-- Reviews: SELECT + INSERT only (immutable — no UPDATE or DELETE)
+CREATE POLICY "Users can view their own reviews"
+  ON public.reviews FOR SELECT TO authenticated
+  USING ((select auth.uid()) = user_id);
+
+CREATE POLICY "Users can insert their own reviews"
+  ON public.reviews FOR INSERT TO authenticated
+  WITH CHECK (
+    (select auth.uid()) = user_id
+    AND EXISTS (
+      SELECT 1 FROM public.cards c
+      WHERE c.card_id = reviews.card_id
+        AND c.user_id = (select auth.uid())
+    )
+  );
+
+-- Session summaries: SELECT + INSERT + UPDATE (never deleted)
+CREATE POLICY "Users can view their own session summaries"
+  ON public.review_session_summary FOR SELECT TO authenticated
+  USING ((select auth.uid()) = user_id);
+
+CREATE POLICY "Users can insert their own session summaries"
+  ON public.review_session_summary FOR INSERT TO authenticated
+  WITH CHECK ((select auth.uid()) = user_id);
+
+CREATE POLICY "Users can update their own session summaries"
+  ON public.review_session_summary FOR UPDATE TO authenticated
+  USING ((select auth.uid()) = user_id)
+  WITH CHECK ((select auth.uid()) = user_id);
+
+-- ══════════════════════════════════════════════════════════════════════
+-- PRIVILEGE MANAGEMENT (REVOKE ALL → explicit GRANT)
+-- ══════════════════════════════════════════════════════════════════════
+
+-- Block anon role entirely — app requires authentication
+REVOKE ALL ON TABLE public.decks FROM anon;
+REVOKE ALL ON TABLE public.cards FROM anon;
+REVOKE ALL ON TABLE public.reviews FROM anon;
+REVOKE ALL ON TABLE public.review_session_summary FROM anon;
+
+-- Revoke all defaults from authenticated, then grant back only what's needed
+REVOKE ALL ON TABLE public.decks FROM authenticated;
+GRANT SELECT, INSERT, UPDATE ON TABLE public.decks TO authenticated;
+
+REVOKE ALL ON TABLE public.cards FROM authenticated;
+GRANT SELECT, INSERT, UPDATE ON TABLE public.cards TO authenticated;
+
+REVOKE ALL ON TABLE public.reviews FROM authenticated;
+GRANT SELECT, INSERT ON TABLE public.reviews TO authenticated;
+
+REVOKE ALL ON TABLE public.review_session_summary FROM authenticated;
+GRANT SELECT, INSERT, UPDATE ON TABLE public.review_session_summary TO authenticated;
+
+COMMIT;


### PR DESCRIPTION
## Summary
- Initializes Supabase project (`config.toml`)
- Adds initial Postgres migration with all 4 tables: `decks`, `cards`, `reviews`, `review_session_summary`
- Schema mirrors local SQLite with Postgres adaptations (uuid PKs without server-side defaults, timestamptz, boolean, CHECK constraints, ON DELETE CASCADE on all user_id FKs)
- Custom `set_updated_at()` PL/pgSQL trigger on mutable tables (decks, cards, session summaries) — no moddatetime extension dependency
- RLS enabled on all tables with per-operation policies using `(select auth.uid())` for per-statement caching and `TO authenticated` to skip anon evaluation
- FK ownership validation via WITH CHECK subqueries on INSERT/UPDATE (prevents cross-user FK references)
- Privilege hardening: REVOKE ALL from both `anon` and `authenticated`, then explicit GRANT of only needed operations (no DELETE anywhere, no UPDATE on reviews)
- Migration wrapped in `BEGIN; ... COMMIT;` for atomicity (Supabase CLI does not auto-wrap)
- Updates CLAUDE.md with Supabase migration and schema guidelines

Phase 2 + 3 of sync schema plan (#8, #95).