### PR TITLE
feat: add offline indicator widget with smart notifications (#106)

### DIFF
--- a/lib/core/services/connectivity_service.dart
+++ b/lib/core/services/connectivity_service.dart
@@ -1,0 +1,110 @@
+import 'package:flutter/material.dart';
+import 'package:connectivity_plus/connectivity_plus.dart';
+
+/// Service for monitoring device connectivity status.
+///
+/// Provides methods to check connectivity and show offline snack bars.
+/// Uses singleton pattern for app-wide access.
+class ConnectivityService {
+  static final ConnectivityService _instance = ConnectivityService._internal();
+
+  final Connectivity _connectivity = Connectivity();
+  bool _isOnline = true;
+  GlobalKey<ScaffoldMessengerState>? _scaffoldMessengerKey;
+  bool _notificationsPaused = false;
+  DateTime? _lastNotificationTime;
+  static const Duration _notificationCooldown = Duration(seconds: 5);
+
+  /// TODO: Wire to user settings (call from settings screen when implemented)
+  /// Example: ConnectivityService().setOfflineNotificationsEnabled(userPreference)
+  bool _showOfflineNotification = true;
+
+  factory ConnectivityService() => _instance;
+
+  ConnectivityService._internal() {
+    _checkInitialConnectivity();
+
+    // Listen for connectivity changes and show snack bar when going offline
+    _connectivity.onConnectivityChanged.listen((results) {
+      final wasOnline = _isOnline;
+      _isOnline = !results.contains(ConnectivityResult.none);
+
+      // Show snack bar if device just went offline (and notifications enabled and not paused)
+      if (wasOnline &&
+          !_isOnline &&
+          _scaffoldMessengerKey != null &&
+          _showOfflineNotification &&
+          !_notificationsPaused) {
+        _tryShowOfflineSnackBar();
+      }
+    });
+  }
+
+  Future<void> _checkInitialConnectivity() async {
+    final result = await _connectivity.checkConnectivity();
+    _isOnline = !result.contains(ConnectivityResult.none);
+  }
+
+  void setScaffoldMessengerKey(GlobalKey<ScaffoldMessengerState> key) {
+    _scaffoldMessengerKey = key;
+  }
+
+  void setOfflineNotificationsEnabled(bool enabled) {
+    _showOfflineNotification = enabled;
+  }
+
+  void pauseNotifications() {
+    _notificationsPaused = true;
+  }
+
+  void resumeNotifications() {
+    _notificationsPaused = false;
+  }
+
+  /// Check if device is currently offline
+  bool get isOffline => !_isOnline;
+
+  /// Check if enough time has passed since last notification (prevents spam on shaky internet)
+  bool _canShowNotification() {
+    final now = DateTime.now();
+    if (_lastNotificationTime == null) return true;
+    return now.difference(_lastNotificationTime!) >= _notificationCooldown;
+  }
+
+  /// Internal method to show snack bar with cooldown check
+  void _tryShowOfflineSnackBar() {
+    if (_canShowNotification()) {
+      _lastNotificationTime = DateTime.now();
+      showOfflineSnackBar();
+    }
+  }
+
+  /// Show offline snack bar if device is offline and notifications are enabled
+  static void showOfflineSnackBar() {
+    final service = ConnectivityService();
+    if (service.isOffline && service._scaffoldMessengerKey != null && service._showOfflineNotification) {
+      service._scaffoldMessengerKey!.currentState?.showSnackBar(
+        const SnackBar(
+          content: Row(
+            children: [
+              Icon(Icons.cloud_off, color: Colors.white, size: 18),
+              SizedBox(width: 12),
+              Expanded(
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text("You're offline"),
+                    // TODO: Wire to actual sync queue count when sync service is implemented
+                    Text('Changes not synced', style: TextStyle(fontSize: 12, color: Colors.white70)),
+                  ],
+                ),
+              ),
+            ],
+          ),
+          duration: Duration(seconds: 3),
+        ),
+      );
+    }
+  }
+}

--- a/lib/features/cards/presentation/screens/card_form_screen.dart
+++ b/lib/features/cards/presentation/screens/card_form_screen.dart
@@ -6,6 +6,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:lapse/core/theme/app_colors.dart';
 import 'package:lapse/core/theme/spacing.dart';
+import 'package:lapse/core/services/connectivity_service.dart';
 import 'package:lapse/core/widgets/app_scaffold.dart';
 import 'package:lapse/core/widgets/confirm_dialog.dart';
 import 'package:lapse/features/cards/data/card_repository_provider.dart';
@@ -73,18 +74,10 @@ class _CardFormScreenState extends ConsumerState<CardFormScreen> {
       context: context,
       builder: (context) => AlertDialog(
         title: const Text('Duplicate card'),
-        content: const Text(
-          'A card with this front already exists in this deck. Save anyway?',
-        ),
+        content: const Text('A card with this front already exists in this deck. Save anyway?'),
         actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(context, false),
-            child: const Text('Cancel'),
-          ),
-          TextButton(
-            onPressed: () => Navigator.pop(context, true),
-            child: const Text('Save anyway'),
-          ),
+          TextButton(onPressed: () => Navigator.pop(context, false), child: const Text('Cancel')),
+          TextButton(onPressed: () => Navigator.pop(context, true), child: const Text('Save anyway')),
         ],
       ),
     );
@@ -115,10 +108,7 @@ class _CardFormScreenState extends ConsumerState<CardFormScreen> {
 
     try {
       if (widget.isEditing) {
-        final updated = widget.card!.copyWith(
-          front: _frontController.text.trim(),
-          back: _backController.text.trim(),
-        );
+        final updated = widget.card!.copyWith(front: _frontController.text.trim(), back: _backController.text.trim());
         await _repo.update(updated);
       } else {
         final card = Flashcard.newCard(
@@ -132,14 +122,12 @@ class _CardFormScreenState extends ConsumerState<CardFormScreen> {
         final label = widget.isEditing
             ? 'Card updated'
             : _createdCount > 0
-                ? '${_createdCount + 1} cards created'
-                : 'Card created';
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-            content: Text(label),
-            duration: const Duration(seconds: 2),
-          ),
-        );
+            ? '${_createdCount + 1} cards created'
+            : 'Card created';
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(SnackBar(content: Text(label), duration: const Duration(seconds: 2)));
+        ConnectivityService.showOfflineSnackBar();
         context.pop();
       }
     } finally {
@@ -194,9 +182,7 @@ class _CardFormScreenState extends ConsumerState<CardFormScreen> {
     if (_createdCount > 0) {
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
-          content: Text(
-            '$_createdCount card${_createdCount == 1 ? '' : 's'} created',
-          ),
+          content: Text('$_createdCount card${_createdCount == 1 ? '' : 's'} created'),
           duration: const Duration(seconds: 2),
         ),
       );
@@ -221,23 +207,15 @@ class _CardFormScreenState extends ConsumerState<CardFormScreen> {
         onBack: _goBack,
         actions: [
           IconButton(
-            icon: Icon(
-              _showPreview ? Icons.edit_outlined : Icons.visibility_outlined,
-            ),
+            icon: Icon(_showPreview ? Icons.edit_outlined : Icons.visibility_outlined),
             onPressed: () => setState(() => _showPreview = !_showPreview),
           ),
-          if (widget.isEditing)
-            IconButton(
-              icon: const Icon(Icons.delete_outline),
-              onPressed: _delete,
-            ),
+          if (widget.isEditing) IconButton(icon: const Icon(Icons.delete_outline), onPressed: _delete),
         ],
         body: Shortcuts(
           shortcuts: const {
-            SingleActivator(LogicalKeyboardKey.enter, shift: true):
-                _SaveAndAddAnotherIntent(),
-            SingleActivator(LogicalKeyboardKey.enter, alt: true):
-                _SaveIntent(),
+            SingleActivator(LogicalKeyboardKey.enter, shift: true): _SaveAndAddAnotherIntent(),
+            SingleActivator(LogicalKeyboardKey.enter, alt: true): _SaveIntent(),
           },
           child: Actions(
             actions: {
@@ -247,8 +225,7 @@ class _CardFormScreenState extends ConsumerState<CardFormScreen> {
                   return null;
                 },
               ),
-              _SaveAndAddAnotherIntent:
-                  CallbackAction<_SaveAndAddAnotherIntent>(
+              _SaveAndAddAnotherIntent: CallbackAction<_SaveAndAddAnotherIntent>(
                 onInvoke: (intent) {
                   if (widget.isEditing) {
                     _save();
@@ -263,11 +240,7 @@ class _CardFormScreenState extends ConsumerState<CardFormScreen> {
               key: _formKey,
               child: Column(
                 children: [
-                  Expanded(
-                    child: _showPreview
-                        ? _buildPreviewContent()
-                        : _buildEditContent(),
-                  ),
+                  Expanded(child: _showPreview ? _buildPreviewContent() : _buildEditContent()),
                   _buildActionButtons(),
                 ],
               ),
@@ -294,10 +267,9 @@ class _CardFormScreenState extends ConsumerState<CardFormScreen> {
             padding: const EdgeInsets.only(bottom: Spacing.lg),
             child: Text(
               '$_createdCount card${_createdCount == 1 ? '' : 's'} added',
-              style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                    color: AppColors.primary,
-                    fontWeight: FontWeight.w500,
-                  ),
+              style: Theme.of(
+                context,
+              ).textTheme.bodySmall?.copyWith(color: AppColors.primary, fontWeight: FontWeight.w500),
             ),
           ),
         TextFormField(
@@ -313,9 +285,7 @@ class _CardFormScreenState extends ConsumerState<CardFormScreen> {
             hintText: 'Question or prompt (Markdown supported)',
             alignLabelWithHint: true,
           ),
-          validator: (value) => (value == null || value.trim().isEmpty)
-              ? 'Front is required'
-              : null,
+          validator: (value) => (value == null || value.trim().isEmpty) ? 'Front is required' : null,
         ),
         const SizedBox(height: Spacing.lg),
         TextFormField(
@@ -329,9 +299,7 @@ class _CardFormScreenState extends ConsumerState<CardFormScreen> {
             hintText: 'Answer (Markdown supported)',
             alignLabelWithHint: true,
           ),
-          validator: (value) => (value == null || value.trim().isEmpty)
-              ? 'Back is required'
-              : null,
+          validator: (value) => (value == null || value.trim().isEmpty) ? 'Back is required' : null,
         ),
         const SizedBox(height: Spacing.md),
         Row(
@@ -339,9 +307,7 @@ class _CardFormScreenState extends ConsumerState<CardFormScreen> {
             Expanded(
               child: Text(
                 '**bold**  *italic*  `code`  # heading  - list  > quote',
-                style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                      color: AppColors.textTertiary,
-                    ),
+                style: Theme.of(context).textTheme.bodySmall?.copyWith(color: AppColors.textTertiary),
               ),
             ),
             const SizedBox(width: Spacing.sm),
@@ -350,19 +316,15 @@ class _CardFormScreenState extends ConsumerState<CardFormScreen> {
               child: Row(
                 mainAxisSize: MainAxisSize.min,
                 children: [
-                  Icon(
-                    Icons.visibility_outlined,
-                    size: 14,
-                    color: AppColors.textTertiary,
-                  ),
+                  Icon(Icons.visibility_outlined, size: 14, color: AppColors.textTertiary),
                   const SizedBox(width: 4),
                   Text(
                     'Preview',
                     style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                          color: AppColors.textTertiary,
-                          decoration: TextDecoration.underline,
-                          decorationColor: AppColors.textTertiary,
-                        ),
+                      color: AppColors.textTertiary,
+                      decoration: TextDecoration.underline,
+                      decorationColor: AppColors.textTertiary,
+                    ),
                   ),
                 ],
               ),
@@ -384,49 +346,30 @@ class _CardFormScreenState extends ConsumerState<CardFormScreen> {
     return ListView(
       padding: const EdgeInsets.all(Spacing.lg),
       children: [
-        _buildPreviewField(
-          label: 'Front',
-          text: _frontController.text,
-          placeholder: '_No front text_',
-        ),
+        _buildPreviewField(label: 'Front', text: _frontController.text, placeholder: '_No front text_'),
         const SizedBox(height: Spacing.lg),
         const Divider(),
         const SizedBox(height: Spacing.lg),
-        _buildPreviewField(
-          label: 'Back',
-          text: _backController.text,
-          placeholder: '_No back text_',
-        ),
+        _buildPreviewField(label: 'Back', text: _backController.text, placeholder: '_No back text_'),
       ],
     );
   }
 
-  Widget _buildPreviewField({
-    required String label,
-    required String text,
-    required String placeholder,
-  }) {
+  Widget _buildPreviewField({required String label, required String text, required String placeholder}) {
     final hasContent = text.trim().isNotEmpty;
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Text(
-          label,
-          style: Theme.of(context)
-              .textTheme
-              .labelMedium
-              ?.copyWith(color: AppColors.textSecondary),
-        ),
+        Text(label, style: Theme.of(context).textTheme.labelMedium?.copyWith(color: AppColors.textSecondary)),
         const SizedBox(height: Spacing.sm),
         MarkdownBody(
           data: hasContent ? text : placeholder,
           onTapLink: (text, href, title) {
             if (href != null) launchUrl(Uri.parse(href));
           },
-          styleSheet:
-              MarkdownStyleSheet.fromTheme(Theme.of(context)).copyWith(
-            p: Theme.of(context).textTheme.bodyLarge,
-          ),
+          styleSheet: MarkdownStyleSheet.fromTheme(
+            Theme.of(context),
+          ).copyWith(p: Theme.of(context).textTheme.bodyLarge),
         ),
       ],
     );
@@ -438,20 +381,10 @@ class _CardFormScreenState extends ConsumerState<CardFormScreen> {
 
   Widget _buildActionButtons() {
     return Container(
-      padding: const EdgeInsets.fromLTRB(
-        Spacing.lg,
-        Spacing.md,
-        Spacing.lg,
-        Spacing.lg,
-      ),
+      padding: const EdgeInsets.fromLTRB(Spacing.lg, Spacing.md, Spacing.lg, Spacing.lg),
       decoration: BoxDecoration(
         color: AppColors.background,
-        border: Border(
-          top: BorderSide(
-            color: AppColors.outlineVariant,
-            width: 0.5,
-          ),
-        ),
+        border: Border(top: BorderSide(color: AppColors.outlineVariant, width: 0.5)),
       ),
       child: SafeArea(
         top: false,

--- a/lib/features/decks/presentation/screens/deck_form_screen.dart
+++ b/lib/features/decks/presentation/screens/deck_form_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:lapse/core/routing/routes.dart';
+import 'package:lapse/core/services/connectivity_service.dart';
 import 'package:lapse/core/theme/spacing.dart';
 import 'package:lapse/core/widgets/app_scaffold.dart';
 import 'package:lapse/core/widgets/confirm_dialog.dart';
@@ -47,9 +48,7 @@ class _DeckFormScreenState extends ConsumerState<DeckFormScreen> {
 
     try {
       final name = _nameController.text.trim();
-      final parentId = widget.isEditing
-          ? widget.deck!.parentId
-          : widget.parentId;
+      final parentId = widget.isEditing ? widget.deck!.parentId : widget.parentId;
       final duplicate = await _repo.nameExistsAtLevel(
         name: name,
         parentId: parentId,
@@ -58,11 +57,9 @@ class _DeckFormScreenState extends ConsumerState<DeckFormScreen> {
       if (duplicate) {
         if (mounted) {
           setState(() => _saving = false);
-          ScaffoldMessenger.of(context).showSnackBar(
-            const SnackBar(
-              content: Text('A deck with this name already exists here'),
-            ),
-          );
+          ScaffoldMessenger.of(
+            context,
+          ).showSnackBar(const SnackBar(content: Text('A deck with this name already exists here')));
         }
         return;
       }
@@ -74,7 +71,10 @@ class _DeckFormScreenState extends ConsumerState<DeckFormScreen> {
         final deck = Deck.create(deckName: name, parentId: widget.parentId);
         await _repo.create(deck);
       }
-      if (mounted) context.pop();
+      if (mounted) {
+        ConnectivityService.showOfflineSnackBar();
+        context.pop();
+      }
     } finally {
       if (mounted) setState(() => _saving = false);
     }
@@ -84,8 +84,7 @@ class _DeckFormScreenState extends ConsumerState<DeckFormScreen> {
     final confirmed = await ConfirmDialog.show(
       context: context,
       title: 'Delete deck?',
-      message:
-          'This will permanently remove "${widget.deck!.deckName}" and all its cards.',
+      message: 'This will permanently remove "${widget.deck!.deckName}" and all its cards.',
       confirmLabel: 'Delete',
       isDestructive: true,
     );
@@ -100,13 +99,7 @@ class _DeckFormScreenState extends ConsumerState<DeckFormScreen> {
     return AppScaffold(
       title: widget.isEditing ? 'Edit Deck' : 'New Deck',
       showBackButton: true,
-      actions: [
-        if (widget.isEditing)
-          IconButton(
-            icon: const Icon(Icons.delete_outline),
-            onPressed: _delete,
-          ),
-      ],
+      actions: [if (widget.isEditing) IconButton(icon: const Icon(Icons.delete_outline), onPressed: _delete)],
       body: Padding(
         padding: const EdgeInsets.all(Spacing.lg),
         child: Form(
@@ -121,13 +114,8 @@ class _DeckFormScreenState extends ConsumerState<DeckFormScreen> {
                 onFieldSubmitted: (_) => _save(),
                 maxLength: maxDeckNameLength,
                 maxLengthEnforcement: MaxLengthEnforcement.enforced,
-                decoration: const InputDecoration(
-                  labelText: 'Deck name',
-                  hintText: 'e.g. Spanish Vocabulary',
-                ),
-                validator: (value) => (value == null || value.trim().isEmpty)
-                    ? 'Name is required'
-                    : null,
+                decoration: const InputDecoration(labelText: 'Deck name', hintText: 'e.g. Spanish Vocabulary'),
+                validator: (value) => (value == null || value.trim().isEmpty) ? 'Name is required' : null,
               ),
               const SizedBox(height: Spacing.xl),
               ElevatedButton(

--- a/lib/features/study/presentation/screens/study_session_screen.dart
+++ b/lib/features/study/presentation/screens/study_session_screen.dart
@@ -6,6 +6,7 @@ import 'package:url_launcher/url_launcher.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:lapse/core/routing/page_transitions.dart' show isDesktop;
+import 'package:lapse/core/services/connectivity_service.dart';
 import 'package:lapse/core/theme/app_colors.dart';
 import 'package:lapse/core/theme/spacing.dart';
 import 'package:lapse/core/widgets/loading_indicator.dart';
@@ -52,30 +53,21 @@ class _ReviewLogEntry {
   final _CardSnapshot after;
   final DateTime timestamp;
 
-  _ReviewLogEntry({
-    required this.cardFront,
-    required this.rating,
-    required this.before,
-    required this.after,
-  }) : timestamp = DateTime.now();
+  _ReviewLogEntry({required this.cardFront, required this.rating, required this.before, required this.after})
+    : timestamp = DateTime.now();
 }
 
 class StudySessionScreen extends ConsumerStatefulWidget {
   final String deckName;
   final List<String> deckIds;
 
-  const StudySessionScreen({
-    super.key,
-    required this.deckName,
-    required this.deckIds,
-  });
+  const StudySessionScreen({super.key, required this.deckName, required this.deckIds});
 
   @override
   ConsumerState<StudySessionScreen> createState() => _StudySessionScreenState();
 }
 
-class _StudySessionScreenState extends ConsumerState<StudySessionScreen>
-    with SingleTickerProviderStateMixin {
+class _StudySessionScreenState extends ConsumerState<StudySessionScreen> with SingleTickerProviderStateMixin {
   CardRepository get _cardRepo => ref.read(cardRepositoryProvider);
   ReviewRepository get _reviewRepo => ref.read(reviewRepositoryProvider);
   final _studySessionService = StudySessionService();
@@ -99,12 +91,7 @@ class _StudySessionScreenState extends ConsumerState<StudySessionScreen>
 
   int _currentIndex = 0;
   bool _showingAnswer = false;
-  final Map<Rating, int> _ratingCounts = {
-    Rating.again: 0,
-    Rating.hard: 0,
-    Rating.good: 0,
-    Rating.easy: 0,
-  };
+  final Map<Rating, int> _ratingCounts = {Rating.again: 0, Rating.hard: 0, Rating.good: 0, Rating.easy: 0};
   final Set<String> _graduatedCardIds = {};
 
   // Debug panel state
@@ -112,20 +99,17 @@ class _StudySessionScreenState extends ConsumerState<StudySessionScreen>
   final List<_ReviewLogEntry> _reviewLog = [];
 
   Flashcard get _currentCard => _cards[_currentIndex];
-  bool get _isSessionComplete =>
-      _cards.isEmpty || _currentIndex >= _cards.length;
-  double get _progress => _initialCardCount == 0
-      ? 0
-      : (_graduatedCardIds.length / _initialCardCount).clamp(0.0, 1.0);
+  bool get _isSessionComplete => _cards.isEmpty || _currentIndex >= _cards.length;
+  double get _progress => _initialCardCount == 0 ? 0 : (_graduatedCardIds.length / _initialCardCount).clamp(0.0, 1.0);
 
   @override
   void initState() {
     super.initState();
+    // Pause offline notifications during study to avoid distraction
+    ConnectivityService().pauseNotifications();
     _focusNode = FocusNode();
-    _dismissController = AnimationController(
-      vsync: this,
-      duration: const Duration(milliseconds: 200),
-    )..addListener(() {
+    _dismissController = AnimationController(vsync: this, duration: const Duration(milliseconds: 200))
+      ..addListener(() {
         final value = _dismissController.value;
         if (value != _dismissOffset) {
           setState(() => _dismissOffset = value);
@@ -136,6 +120,8 @@ class _StudySessionScreenState extends ConsumerState<StudySessionScreen>
 
   @override
   void dispose() {
+    // Resume notifications when leaving study session
+    ConnectivityService().resumeNotifications();
     _focusNode.dispose();
     _dismissController.dispose();
     super.dispose();
@@ -157,19 +143,14 @@ class _StudySessionScreenState extends ConsumerState<StudySessionScreen>
         setState(() {
           _cards = allCards;
           _initialCardCount = allCards.length;
-          _session = _studySessionService.startSession(
-            widget.deckIds.first,
-            _cards,
-          );
+          _session = _studySessionService.startSession(widget.deckIds.first, _cards);
           _isLoading = false;
         });
       }
     } catch (e) {
       if (mounted) {
         setState(() => _isLoading = false);
-        ScaffoldMessenger.of(
-          context,
-        ).showSnackBar(SnackBar(content: Text('Failed to load cards: $e')));
+        ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text('Failed to load cards: $e')));
       }
     }
   }
@@ -197,11 +178,7 @@ class _StudySessionScreenState extends ConsumerState<StudySessionScreen>
     _isProcessing = true;
     try {
       final before = _CardSnapshot.fromCard(_currentCard);
-      final result = _studySessionService.rateCard(
-        _session,
-        _currentCard,
-        rating,
-      );
+      final result = _studySessionService.rateCard(_session, _currentCard, rating);
       await _cardRepo.update(result.updatedCard);
       await _reviewRepo.addReview(result.review);
       final after = _CardSnapshot.fromCard(result.updatedCard);
@@ -216,22 +193,13 @@ class _StudySessionScreenState extends ConsumerState<StudySessionScreen>
         if (result.updatedCard.cardState == CardState.review) {
           _graduatedCardIds.add(result.updatedCard.cardId);
         }
-        _reviewLog.add(
-          _ReviewLogEntry(
-            cardFront: _currentCard.front,
-            rating: rating,
-            before: before,
-            after: after,
-          ),
-        );
+        _reviewLog.add(_ReviewLogEntry(cardFront: _currentCard.front, rating: rating, before: before, after: after));
         _currentIndex++;
         _showingAnswer = false;
       });
     } catch (e) {
       if (mounted) {
-        ScaffoldMessenger.of(
-          context,
-        ).showSnackBar(SnackBar(content: Text('Failed to save review: $e')));
+        ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text('Failed to save review: $e')));
       }
     } finally {
       _isProcessing = false;
@@ -243,21 +211,15 @@ class _StudySessionScreenState extends ConsumerState<StudySessionScreen>
     return Scaffold(
       backgroundColor: AppColors.background,
       appBar: AppBar(
-        leading: IconButton(
-          icon: const Icon(Icons.close),
-          onPressed: () => _showExitConfirmation(context),
-        ),
+        leading: IconButton(icon: const Icon(Icons.close), onPressed: () => _showExitConfirmation(context)),
         title: Text(widget.deckName),
         centerTitle: true,
         actions: [
           if (kDebugMode)
             IconButton(
-              icon: Icon(
-                _showDebugPanel ? Icons.bug_report : Icons.bug_report_outlined,
-              ),
+              icon: Icon(_showDebugPanel ? Icons.bug_report : Icons.bug_report_outlined),
               color: _showDebugPanel ? AppColors.warning : null,
-              onPressed: () =>
-                  setState(() => _showDebugPanel = !_showDebugPanel),
+              onPressed: () => setState(() => _showDebugPanel = !_showDebugPanel),
             ),
         ],
       ),
@@ -267,11 +229,7 @@ class _StudySessionScreenState extends ConsumerState<StudySessionScreen>
               children: [
                 _buildProgressBar(),
                 if (_showDebugPanel) _buildDebugPanel(),
-                Expanded(
-                  child: _isSessionComplete
-                      ? _buildSessionComplete()
-                      : _buildStudyCard(),
-                ),
+                Expanded(child: _isSessionComplete ? _buildSessionComplete() : _buildStudyCard()),
               ],
             ),
     );
@@ -286,11 +244,7 @@ class _StudySessionScreenState extends ConsumerState<StudySessionScreen>
         alignment: Alignment.centerLeft,
         widthFactor: _progress,
         child: Container(
-          decoration: BoxDecoration(
-            gradient: LinearGradient(
-              colors: [AppColors.primary, AppColors.secondary],
-            ),
-          ),
+          decoration: BoxDecoration(gradient: LinearGradient(colors: [AppColors.primary, AppColors.secondary])),
         ),
       ),
     );
@@ -302,9 +256,7 @@ class _StudySessionScreenState extends ConsumerState<StudySessionScreen>
     if (!_isSessionComplete) {
       final c = _currentCard;
       currentCardInfo = _buildDebugSection('Next Card', AppColors.primary, {
-        'front': c.front.length > 40
-            ? '${c.front.substring(0, 40)}...'
-            : c.front,
+        'front': c.front.length > 40 ? '${c.front.substring(0, 40)}...' : c.front,
         'state': c.cardState.name,
         'step': '${c.step ?? '-'}',
         'stability': c.stability.toStringAsFixed(4),
@@ -312,9 +264,7 @@ class _StudySessionScreenState extends ConsumerState<StudySessionScreen>
         'reps': '${c.reps}',
         'lapses': '${c.lapses}',
         'due': _formatDate(c.dueDate),
-        'lastReview': c.lastReview != null
-            ? _formatDate(c.lastReview!)
-            : 'never',
+        'lastReview': c.lastReview != null ? _formatDate(c.lastReview!) : 'never',
       });
     }
 
@@ -322,23 +272,15 @@ class _StudySessionScreenState extends ConsumerState<StudySessionScreen>
       constraints: const BoxConstraints(maxHeight: 260),
       decoration: const BoxDecoration(
         color: Color(0xFF1A1A20),
-        border: Border(
-          bottom: BorderSide(color: AppColors.outline, width: 0.5),
-        ),
+        border: Border(bottom: BorderSide(color: AppColors.outline, width: 0.5)),
       ),
       child: ListView(
-        padding: const EdgeInsets.symmetric(
-          horizontal: Spacing.md,
-          vertical: Spacing.sm,
-        ),
+        padding: const EdgeInsets.symmetric(horizontal: Spacing.md, vertical: Spacing.sm),
         children: [
           ?currentCardInfo,
           if (_reviewLog.isNotEmpty) ...[
             Padding(
-              padding: const EdgeInsets.only(
-                top: Spacing.sm,
-                bottom: Spacing.xs,
-              ),
+              padding: const EdgeInsets.only(top: Spacing.sm, bottom: Spacing.xs),
               child: Text(
                 'Review Log (${_reviewLog.length})',
                 style: const TextStyle(
@@ -394,23 +336,14 @@ class _StudySessionScreenState extends ConsumerState<StudySessionScreen>
                 ),
                 child: Text(
                   entry.rating.name.toUpperCase(),
-                  style: TextStyle(
-                    color: ratingColor,
-                    fontSize: 10,
-                    fontWeight: FontWeight.w700,
-                  ),
+                  style: TextStyle(color: ratingColor, fontSize: 10, fontWeight: FontWeight.w700),
                 ),
               ),
               const SizedBox(width: Spacing.sm),
               Expanded(
                 child: Text(
-                  entry.cardFront.length > 30
-                      ? '${entry.cardFront.substring(0, 30)}...'
-                      : entry.cardFront,
-                  style: const TextStyle(
-                    color: AppColors.textSecondary,
-                    fontSize: 11,
-                  ),
+                  entry.cardFront.length > 30 ? '${entry.cardFront.substring(0, 30)}...' : entry.cardFront,
+                  style: const TextStyle(color: AppColors.textSecondary, fontSize: 11),
                   overflow: TextOverflow.ellipsis,
                 ),
               ),
@@ -427,33 +360,17 @@ class _StudySessionScreenState extends ConsumerState<StudySessionScreen>
     final rows = <_DiffRow>[
       _DiffRow('state', before.cardState.name, after.cardState.name),
       _DiffRow('step', '${before.step ?? '-'}', '${after.step ?? '-'}'),
-      _DiffRow(
-        'stability',
-        before.stability.toStringAsFixed(4),
-        after.stability.toStringAsFixed(4),
-      ),
-      _DiffRow(
-        'difficulty',
-        before.difficulty.toStringAsFixed(4),
-        after.difficulty.toStringAsFixed(4),
-      ),
+      _DiffRow('stability', before.stability.toStringAsFixed(4), after.stability.toStringAsFixed(4)),
+      _DiffRow('difficulty', before.difficulty.toStringAsFixed(4), after.difficulty.toStringAsFixed(4)),
       _DiffRow('reps', '${before.reps}', '${after.reps}'),
       _DiffRow('lapses', '${before.lapses}', '${after.lapses}'),
       _DiffRow('due', _formatDate(before.dueDate), _formatDate(after.dueDate)),
-      _DiffRow(
-        'scheduledDays',
-        '${before.scheduledDays}',
-        '${after.scheduledDays}',
-      ),
+      _DiffRow('scheduledDays', '${before.scheduledDays}', '${after.scheduledDays}'),
       _DiffRow('elapsedDays', '${before.elapsedDays}', '${after.elapsedDays}'),
     ];
 
     return DefaultTextStyle(
-      style: const TextStyle(
-        fontFamily: 'monospace',
-        fontSize: 11,
-        color: AppColors.textSecondary,
-      ),
+      style: const TextStyle(fontFamily: 'monospace', fontSize: 11, color: AppColors.textSecondary),
       child: Table(
         columnWidths: const {
           0: FixedColumnWidth(90),
@@ -465,24 +382,14 @@ class _StudySessionScreenState extends ConsumerState<StudySessionScreen>
           for (final row in rows)
             TableRow(
               children: [
-                Text(
-                  row.label,
-                  style: const TextStyle(color: AppColors.textTertiary),
-                ),
+                Text(row.label, style: const TextStyle(color: AppColors.textTertiary)),
                 Text(row.before),
-                const Text(
-                  ' → ',
-                  style: TextStyle(color: AppColors.textTertiary),
-                ),
+                const Text(' → ', style: TextStyle(color: AppColors.textTertiary)),
                 Text(
                   row.after,
                   style: TextStyle(
-                    color: row.before != row.after
-                        ? AppColors.success
-                        : AppColors.textSecondary,
-                    fontWeight: row.before != row.after
-                        ? FontWeight.w600
-                        : FontWeight.normal,
+                    color: row.before != row.after ? AppColors.success : AppColors.textSecondary,
+                    fontWeight: row.before != row.after ? FontWeight.w600 : FontWeight.normal,
                   ),
                 ),
               ],
@@ -492,11 +399,7 @@ class _StudySessionScreenState extends ConsumerState<StudySessionScreen>
     );
   }
 
-  Widget _buildDebugSection(
-    String title,
-    Color color,
-    Map<String, String> fields,
-  ) {
+  Widget _buildDebugSection(String title, Color color, Map<String, String> fields) {
     return Container(
       margin: const EdgeInsets.only(bottom: Spacing.xs),
       padding: const EdgeInsets.all(Spacing.sm),
@@ -510,19 +413,11 @@ class _StudySessionScreenState extends ConsumerState<StudySessionScreen>
         children: [
           Text(
             title,
-            style: TextStyle(
-              color: color,
-              fontSize: 11,
-              fontWeight: FontWeight.w600,
-            ),
+            style: TextStyle(color: color, fontSize: 11, fontWeight: FontWeight.w600),
           ),
           const SizedBox(height: 4),
           DefaultTextStyle(
-            style: const TextStyle(
-              fontFamily: 'monospace',
-              fontSize: 11,
-              color: AppColors.textSecondary,
-            ),
+            style: const TextStyle(fontFamily: 'monospace', fontSize: 11, color: AppColors.textSecondary),
             child: Column(
               children: [
                 for (final e in fields.entries)
@@ -530,10 +425,7 @@ class _StudySessionScreenState extends ConsumerState<StudySessionScreen>
                     children: [
                       SizedBox(
                         width: 90,
-                        child: Text(
-                          e.key,
-                          style: const TextStyle(color: AppColors.textTertiary),
-                        ),
+                        child: Text(e.key, style: const TextStyle(color: AppColors.textTertiary)),
                       ),
                       Expanded(child: Text(e.value)),
                     ],
@@ -593,29 +485,15 @@ class _StudySessionScreenState extends ConsumerState<StudySessionScreen>
                     onTapLink: (text, href, title) {
                       if (href != null) launchUrl(Uri.parse(href));
                     },
-                    styleSheet: MarkdownStyleSheet.fromTheme(
-                      Theme.of(context),
-                    ).copyWith(
-                      p: Theme.of(context)
-                          .textTheme
-                          .headlineSmall
-                          ?.copyWith(fontWeight: FontWeight.normal),
-                      strong: Theme.of(context)
-                          .textTheme
-                          .headlineSmall
-                          ?.copyWith(fontWeight: FontWeight.bold),
+                    styleSheet: MarkdownStyleSheet.fromTheme(Theme.of(context)).copyWith(
+                      p: Theme.of(context).textTheme.headlineSmall?.copyWith(fontWeight: FontWeight.normal),
+                      strong: Theme.of(context).textTheme.headlineSmall?.copyWith(fontWeight: FontWeight.bold),
                       textAlign: WrapAlignment.center,
-                      listBullet: Theme.of(context)
-                          .textTheme
-                          .headlineSmall
-                          ?.copyWith(fontWeight: FontWeight.normal),
-                      blockquote: Theme.of(context)
-                          .textTheme
-                          .headlineSmall
-                          ?.copyWith(
-                            fontWeight: FontWeight.normal,
-                            color: AppColors.textSecondary,
-                          ),
+                      listBullet: Theme.of(context).textTheme.headlineSmall?.copyWith(fontWeight: FontWeight.normal),
+                      blockquote: Theme.of(context).textTheme.headlineSmall?.copyWith(
+                        fontWeight: FontWeight.normal,
+                        color: AppColors.textSecondary,
+                      ),
                     ),
                   ),
                 ),
@@ -649,10 +527,7 @@ class _StudySessionScreenState extends ConsumerState<StudySessionScreen>
             child: Text(
               'Tap to reveal',
               textAlign: TextAlign.center,
-              style: Theme.of(context)
-                  .textTheme
-                  .bodySmall
-                  ?.copyWith(color: AppColors.textTertiary),
+              style: Theme.of(context).textTheme.bodySmall?.copyWith(color: AppColors.textTertiary),
             ),
           ),
         ],
@@ -689,16 +564,13 @@ class _StudySessionScreenState extends ConsumerState<StudySessionScreen>
               dismissProgress: isDesktop ? _dismissOffset : _swipeProgress,
               topCard: LayoutBuilder(
                 builder: (context, constraints) {
-                  final dx = -constraints.maxWidth *
-                      Curves.easeIn.transform(_dismissOffset);
+                  final dx = -constraints.maxWidth * Curves.easeIn.transform(_dismissOffset);
                   return Transform.translate(
                     offset: Offset(dx, 0),
                     child: Opacity(
                       opacity: 1.0 - _dismissOffset,
                       child: MouseRegion(
-                        cursor: _showingAnswer
-                            ? SystemMouseCursors.basic
-                            : SystemMouseCursors.click,
+                        cursor: _showingAnswer ? SystemMouseCursors.basic : SystemMouseCursors.click,
                         child: flipCard,
                       ),
                     ),
@@ -730,29 +602,13 @@ class _StudySessionScreenState extends ConsumerState<StudySessionScreen>
         ignoring: !_showingAnswer || _dismissOffset > 0,
         child: Row(
           children: [
-            _RatingButton(
-              label: 'Again',
-              color: AppColors.ratingAgain,
-              onPressed: () => _dismissAndRate(Rating.again),
-            ),
+            _RatingButton(label: 'Again', color: AppColors.ratingAgain, onPressed: () => _dismissAndRate(Rating.again)),
             const SizedBox(width: Spacing.sm),
-            _RatingButton(
-              label: 'Hard',
-              color: AppColors.ratingHard,
-              onPressed: () => _dismissAndRate(Rating.hard),
-            ),
+            _RatingButton(label: 'Hard', color: AppColors.ratingHard, onPressed: () => _dismissAndRate(Rating.hard)),
             const SizedBox(width: Spacing.sm),
-            _RatingButton(
-              label: 'Good',
-              color: AppColors.ratingGood,
-              onPressed: () => _dismissAndRate(Rating.good),
-            ),
+            _RatingButton(label: 'Good', color: AppColors.ratingGood, onPressed: () => _dismissAndRate(Rating.good)),
             const SizedBox(width: Spacing.sm),
-            _RatingButton(
-              label: 'Easy',
-              color: AppColors.ratingEasy,
-              onPressed: () => _dismissAndRate(Rating.easy),
-            ),
+            _RatingButton(label: 'Easy', color: AppColors.ratingEasy, onPressed: () => _dismissAndRate(Rating.easy)),
           ],
         ),
       ),
@@ -769,16 +625,11 @@ class _StudySessionScreenState extends ConsumerState<StudySessionScreen>
         children: [
           Icon(Icons.celebration_outlined, size: 64, color: AppColors.primary),
           const SizedBox(height: Spacing.lg),
-          Text(
-            'Session Complete!',
-            style: Theme.of(context).textTheme.headlineMedium,
-          ),
+          Text('Session Complete!', style: Theme.of(context).textTheme.headlineMedium),
           const SizedBox(height: Spacing.sm),
           Text(
             'You reviewed $totalReviewed cards',
-            style: Theme.of(
-              context,
-            ).textTheme.bodyLarge?.copyWith(color: AppColors.textSecondary),
+            style: Theme.of(context).textTheme.bodyLarge?.copyWith(color: AppColors.textSecondary),
           ),
           const SizedBox(height: Spacing.xxl),
           _buildStatsGrid(),
@@ -786,7 +637,10 @@ class _StudySessionScreenState extends ConsumerState<StudySessionScreen>
           SizedBox(
             width: double.infinity,
             child: ElevatedButton(
-              onPressed: () => context.pop(),
+              onPressed: () {
+                ConnectivityService.showOfflineSnackBar();
+                context.pop();
+              },
               child: const Text('Done'),
             ),
           ),
@@ -799,26 +653,10 @@ class _StudySessionScreenState extends ConsumerState<StudySessionScreen>
     return Row(
       mainAxisAlignment: MainAxisAlignment.spaceEvenly,
       children: [
-        _StatItem(
-          label: 'Again',
-          count: _ratingCounts[Rating.again]!,
-          color: AppColors.ratingAgain,
-        ),
-        _StatItem(
-          label: 'Hard',
-          count: _ratingCounts[Rating.hard]!,
-          color: AppColors.ratingHard,
-        ),
-        _StatItem(
-          label: 'Good',
-          count: _ratingCounts[Rating.good]!,
-          color: AppColors.ratingGood,
-        ),
-        _StatItem(
-          label: 'Easy',
-          count: _ratingCounts[Rating.easy]!,
-          color: AppColors.ratingEasy,
-        ),
+        _StatItem(label: 'Again', count: _ratingCounts[Rating.again]!, color: AppColors.ratingAgain),
+        _StatItem(label: 'Hard', count: _ratingCounts[Rating.hard]!, color: AppColors.ratingHard),
+        _StatItem(label: 'Good', count: _ratingCounts[Rating.good]!, color: AppColors.ratingGood),
+        _StatItem(label: 'Easy', count: _ratingCounts[Rating.easy]!, color: AppColors.ratingEasy),
       ],
     );
   }
@@ -828,18 +666,10 @@ class _StudySessionScreenState extends ConsumerState<StudySessionScreen>
       context: context,
       builder: (context) => AlertDialog(
         title: const Text('End session?'),
-        content: const Text(
-          'Already-reviewed cards are saved. You can resume later.',
-        ),
+        content: const Text('Already-reviewed cards are saved. You can resume later.'),
         actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(context, false),
-            child: const Text('Cancel'),
-          ),
-          TextButton(
-            onPressed: () => Navigator.pop(context, true),
-            child: const Text('End'),
-          ),
+          TextButton(onPressed: () => Navigator.pop(context, false), child: const Text('Cancel')),
+          TextButton(onPressed: () => Navigator.pop(context, true), child: const Text('End')),
         ],
       ),
     );
@@ -854,11 +684,7 @@ class _RatingButton extends StatelessWidget {
   final Color color;
   final VoidCallback onPressed;
 
-  const _RatingButton({
-    required this.label,
-    required this.color,
-    required this.onPressed,
-  });
+  const _RatingButton({required this.label, required this.color, required this.onPressed});
 
   @override
   Widget build(BuildContext context) {
@@ -891,11 +717,7 @@ class _StatItem extends StatelessWidget {
   final int count;
   final Color color;
 
-  const _StatItem({
-    required this.label,
-    required this.count,
-    required this.color,
-  });
+  const _StatItem({required this.label, required this.count, required this.color});
 
   @override
   Widget build(BuildContext context) {
@@ -903,18 +725,10 @@ class _StatItem extends StatelessWidget {
       children: [
         Text(
           '$count',
-          style: Theme.of(context).textTheme.headlineSmall?.copyWith(
-            color: color,
-            fontWeight: FontWeight.bold,
-          ),
+          style: Theme.of(context).textTheme.headlineSmall?.copyWith(color: color, fontWeight: FontWeight.bold),
         ),
         const SizedBox(height: Spacing.xs),
-        Text(
-          label,
-          style: Theme.of(
-            context,
-          ).textTheme.bodySmall?.copyWith(color: AppColors.textSecondary),
-        ),
+        Text(label, style: Theme.of(context).textTheme.bodySmall?.copyWith(color: AppColors.textSecondary)),
       ],
     );
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -6,6 +6,7 @@ import 'package:sqflite_common_ffi/sqflite_ffi.dart';
 import 'package:window_manager/window_manager.dart';
 import 'core/routing/app_router.dart';
 import 'core/routing/page_transitions.dart';
+import 'core/services/connectivity_service.dart';
 import 'core/supabase/supabase_config.dart';
 import 'core/theme/app_theme.dart';
 import 'core/widgets/window_title_bar.dart';
@@ -23,8 +24,7 @@ void main() async {
         size: const Size(1280, 720),
         minimumSize: const Size(400, 500),
         center: true,
-        titleBarStyle:
-            Platform.isMacOS ? TitleBarStyle.normal : TitleBarStyle.hidden,
+        titleBarStyle: Platform.isMacOS ? TitleBarStyle.normal : TitleBarStyle.hidden,
       ),
       () async {
         await windowManager.show();
@@ -35,35 +35,58 @@ void main() async {
 
   await SupabaseConfig.initialize();
 
-  runApp(const ProviderScope(child: LapseApp()));
+  // Initialize connectivity service with scaffold messenger key
+  final scaffoldMessengerKey = GlobalKey<ScaffoldMessengerState>();
+  ConnectivityService().setScaffoldMessengerKey(scaffoldMessengerKey);
+
+  runApp(LapseApp(scaffoldMessengerKey: scaffoldMessengerKey));
 }
 
-class LapseApp extends StatelessWidget {
-  const LapseApp({super.key});
+class LapseApp extends StatefulWidget {
+  final GlobalKey<ScaffoldMessengerState> scaffoldMessengerKey;
+
+  const LapseApp({super.key, required this.scaffoldMessengerKey});
+
+  @override
+  State<LapseApp> createState() => _LapseAppState();
+}
+
+class _LapseAppState extends State<LapseApp> {
+  @override
+  void initState() {
+    super.initState();
+    // Show offline snack bar on startup if offline
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      ConnectivityService.showOfflineSnackBar();
+    });
+  }
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp.router(
-      title: 'Lapse',
-      debugShowCheckedModeBanner: false,
-      theme: AppTheme.light,
-      darkTheme: AppTheme.dark,
-      themeMode: ThemeMode.dark,
-      routerConfig: appRouter,
-      builder: (context, child) {
-        Widget content = child ?? const SizedBox();
+    return ProviderScope(
+      child: MaterialApp.router(
+        title: 'Lapse',
+        debugShowCheckedModeBanner: false,
+        theme: AppTheme.light,
+        darkTheme: AppTheme.dark,
+        themeMode: ThemeMode.dark,
+        scaffoldMessengerKey: widget.scaffoldMessengerKey,
+        routerConfig: appRouter,
+        builder: (context, child) {
+          Widget content = child ?? const SizedBox();
 
-        if (isDesktop && !Platform.isMacOS) {
-          content = Column(
-            children: [
-              const WindowTitleBar(),
-              Expanded(child: content),
-            ],
-          );
-        }
+          if (isDesktop && !Platform.isMacOS) {
+            content = Column(
+              children: [
+                const WindowTitleBar(),
+                Expanded(child: content),
+              ],
+            );
+          }
 
-        return content;
-      },
+          return content;
+        },
+      ),
     );
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -153,6 +153,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.19.1"
+  connectivity_plus:
+    dependency: "direct main"
+    description:
+      name: connectivity_plus
+      sha256: "33bae12a398f841c6cda09d1064212957265869104c478e5ad51e2fb26c3973c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.0"
+  connectivity_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: connectivity_plus_platform_interface
+      sha256: "42657c1715d48b167930d5f34d00222ac100475f73d10162ddf43e714932f204"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
   convert:
     dependency: transitive
     description:
@@ -536,6 +552,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.17.4"
+  nm:
+    dependency: transitive
+    description:
+      name: nm
+      sha256: "2c9aae4127bdc8993206464fcc063611e0e36e72018696cd9631023a31b24254"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.5.0"
   node_preamble:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -51,6 +51,7 @@ dependencies:
   supabase_flutter: ^2.12.0
   shared_preferences: ^2.5.4
   package_info_plus: ^9.0.0
+  connectivity_plus: ^7.0.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Adds real-time connectivity monitoring with smart offline notifications:
  - Shows snack bars when device goes offline (app startup, WiFi drop, after form saves, after study)
  - 5-second cooldown to prevent spam on flaky networks
  - Pauses notifications during study sessions to avoid distraction
  - Configurable via `setOfflineNotificationsEnabled()`, defaults to ON
  - Includes stub for future sync queue integration

Files reformatted automatically by `dart format`.

Closes (#106)