### PR TITLE
feat: context menu overhaul (#116, #117, #156)

### DIFF
--- a/lib/core/theme/app_theme.dart
+++ b/lib/core/theme/app_theme.dart
@@ -139,6 +139,13 @@ abstract class AppTheme {
         borderRadius: BorderRadius.circular(Spacing.radiusXl),
       ),
     ),
+    popupMenuTheme: PopupMenuThemeData(
+      color: AppColors.surfaceElevated,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(Spacing.radiusLg),
+        side: const BorderSide(color: AppColors.outline, width: 1),
+      ),
+    ),
     textTheme: const TextTheme(
       headlineLarge: TextStyle(
         color: AppColors.textPrimary,

--- a/lib/core/widgets/context_menu_region.dart
+++ b/lib/core/widgets/context_menu_region.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import '../theme/app_colors.dart';
+import '../theme/spacing.dart';
 
 enum ContextMenuAction { edit, delete, move }
 
@@ -7,16 +9,33 @@ enum ContextMenuAction { edit, delete, move }
 const List<PopupMenuEntry<ContextMenuAction>> kDefaultContextMenuItems = [
   PopupMenuItem<ContextMenuAction>(
     value: ContextMenuAction.edit,
-    child: Text('Edit'),
+    child: Row(
+      children: [
+        Icon(Icons.edit_outlined, size: 18, color: AppColors.textSecondary),
+        SizedBox(width: Spacing.md),
+        Text('Edit'),
+      ],
+    ),
   ),
   PopupMenuItem<ContextMenuAction>(
     value: ContextMenuAction.delete,
-    child: Text('Delete'),
+    child: Row(
+      children: [
+        Icon(Icons.delete_outline, size: 18, color: AppColors.textSecondary),
+        SizedBox(width: Spacing.md),
+        Text('Delete'),
+      ],
+    ),
   ),
   PopupMenuItem<ContextMenuAction>(
     value: ContextMenuAction.move,
-    enabled: false,
-    child: Text('Move (Coming soon)'),
+    child: Row(
+      children: [
+        Icon(Icons.folder_open_outlined, size: 18, color: AppColors.textSecondary),
+        SizedBox(width: Spacing.md),
+        Text('Move'),
+      ],
+    ),
   ),
 ];
 
@@ -62,9 +81,9 @@ class ContextMenuRegion extends StatelessWidget {
     return GestureDetector(
       onSecondaryTapDown: (details) =>
           _show(context, globalPosition: details.globalPosition),
-      onLongPress: () {
+      onLongPressStart: (details) {
         HapticFeedback.heavyImpact();
-        _show(context);
+        _show(context, globalPosition: details.globalPosition);
       },
       child: child,
     );

--- a/lib/core/widgets/deck_picker_dialog.dart
+++ b/lib/core/widgets/deck_picker_dialog.dart
@@ -1,0 +1,206 @@
+import 'package:flutter/material.dart';
+import '../theme/app_colors.dart';
+import '../theme/spacing.dart';
+import '../../features/decks/domain/deck.dart';
+
+/// Dialog for selecting a destination deck when moving a deck or card.
+///
+/// Returns the selected deck ID via [show]:
+/// - `null` = cancelled
+/// - `''` (empty) = root level
+/// - non-empty = specific deck ID
+class DeckPickerDialog extends StatefulWidget {
+  final List<Deck> decks;
+  final Set<String> excludeIds;
+  final String? currentParentId;
+  final bool showRoot;
+
+  const DeckPickerDialog({
+    super.key,
+    required this.decks,
+    required this.excludeIds,
+    this.currentParentId,
+    this.showRoot = true,
+  });
+
+  static Future<String?> show({
+    required BuildContext context,
+    required List<Deck> decks,
+    required Set<String> excludeIds,
+    String? currentParentId,
+    bool showRoot = true,
+  }) {
+    return showDialog<String>(
+      context: context,
+      builder: (context) => DeckPickerDialog(
+        decks: decks,
+        excludeIds: excludeIds,
+        currentParentId: currentParentId,
+        showRoot: showRoot,
+      ),
+    );
+  }
+
+  @override
+  State<DeckPickerDialog> createState() => _DeckPickerDialogState();
+}
+
+class _DeckPickerDialogState extends State<DeckPickerDialog> {
+  String? _selectedId;
+
+  @override
+  void initState() {
+    super.initState();
+    _selectedId = widget.showRoot ? '' : null;
+  }
+
+  /// Whether a new (non-current) destination has been picked.
+  bool get _hasNewSelection {
+    if (_selectedId == null) return false;
+    // Root selected and current parent is already root.
+    if (_selectedId!.isEmpty && widget.currentParentId == null) return false;
+    // Specific deck selected that matches current parent.
+    if (_selectedId == widget.currentParentId) return false;
+    return true;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final available = widget.decks
+        .where((d) => !widget.excludeIds.contains(d.deckId))
+        .toList();
+
+    // Group decks by parentId to build the tree.
+    final childrenMap = <String?, List<Deck>>{};
+    for (final deck in available) {
+      childrenMap.putIfAbsent(deck.parentId, () => []).add(deck);
+    }
+
+    final treeItems = <Widget>[
+      if (widget.showRoot)
+        _buildTile(
+          label: 'Root (top level)',
+          icon: Icons.home_outlined,
+          id: '',
+          indent: 0,
+          isCurrent: widget.currentParentId == null,
+        ),
+      ..._buildTree(childrenMap, null, 0),
+    ];
+
+    return AlertDialog(
+      title: const Text('Move to'),
+      content: SizedBox(
+        width: double.maxFinite,
+        child: treeItems.isEmpty
+            ? const Padding(
+                padding: EdgeInsets.symmetric(vertical: Spacing.lg),
+                child: Text(
+                  'No destinations available',
+                  style: TextStyle(color: AppColors.textSecondary),
+                ),
+              )
+            : ListView(shrinkWrap: true, children: treeItems),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('Cancel'),
+        ),
+        if (_hasNewSelection)
+          FilledButton(
+            onPressed: () => Navigator.of(context).pop(_selectedId),
+            child: const Text('Move'),
+          )
+        else
+          TextButton(
+            onPressed: null,
+            child: const Text('Move'),
+          ),
+      ],
+    );
+  }
+
+  List<Widget> _buildTree(
+    Map<String?, List<Deck>> childrenMap,
+    String? parentId,
+    int depth,
+  ) {
+    final children = childrenMap[parentId];
+    if (children == null) return const [];
+
+    final widgets = <Widget>[];
+    for (final deck in children) {
+      widgets.add(_buildTile(
+        label: deck.deckName,
+        icon: Icons.folder_outlined,
+        id: deck.deckId,
+        indent: depth + 1,
+        isCurrent: widget.currentParentId == deck.deckId,
+      ));
+      widgets.addAll(_buildTree(childrenMap, deck.deckId, depth + 1));
+    }
+    return widgets;
+  }
+
+  Widget _buildTile({
+    required String label,
+    required IconData icon,
+    required String id,
+    required int indent,
+    required bool isCurrent,
+  }) {
+    final isSelected = _selectedId == id;
+    final isNewSelection = isSelected && !isCurrent;
+
+    return Padding(
+      padding: EdgeInsets.only(left: Spacing.lg * indent),
+      child: Material(
+        color: isNewSelection
+            ? AppColors.primary.withValues(alpha: 0.12)
+            : Colors.transparent,
+        borderRadius: BorderRadius.circular(Spacing.radiusSm),
+        child: InkWell(
+          onTap: isCurrent ? null : () => setState(() => _selectedId = id),
+          borderRadius: BorderRadius.circular(Spacing.radiusSm),
+          child: Padding(
+            padding: const EdgeInsets.symmetric(
+              horizontal: Spacing.sm,
+              vertical: Spacing.sm,
+            ),
+            child: Row(
+              children: [
+                Icon(
+                  icon,
+                  size: 20,
+                  color: isNewSelection
+                      ? AppColors.primary
+                      : AppColors.textSecondary,
+                ),
+                const SizedBox(width: Spacing.sm),
+                Expanded(
+                  child: Text(
+                    isCurrent ? '$label (current)' : label,
+                    style: TextStyle(
+                      color: isCurrent
+                          ? AppColors.textTertiary
+                          : isNewSelection
+                              ? AppColors.primary
+                              : AppColors.textPrimary,
+                      fontWeight:
+                          isNewSelection ? FontWeight.w600 : FontWeight.normal,
+                    ),
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ),
+                if (isSelected)
+                  const Icon(Icons.check, size: 18, color: AppColors.primary),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/core/widgets/dev_drawer.dart
+++ b/lib/core/widgets/dev_drawer.dart
@@ -244,8 +244,25 @@ class DevDrawer extends StatelessWidget {
             leading: const Icon(Icons.notifications_outlined),
             title: const Text('Trigger Snackbar'),
             onTap: () {
-              Navigator.pop(context);
+              Scaffold.of(context).closeDrawer();
               AppSnackBar.show(context, 'Test snackbar message');
+            },
+          ),
+          const Divider(),
+          ListTile(
+            leading: const Icon(Icons.file_upload_outlined),
+            title: const Text('Import'),
+            onTap: () {
+              Scaffold.of(context).closeDrawer();
+              AppSnackBar.show(context, 'Import triggered (not wired up)');
+            },
+          ),
+          ListTile(
+            leading: const Icon(Icons.file_download_outlined),
+            title: const Text('Export'),
+            onTap: () {
+              Scaffold.of(context).closeDrawer();
+              AppSnackBar.show(context, 'Export triggered (not wired up)');
             },
           ),
           const Divider(),

--- a/lib/features/decks/presentation/providers/deck_detail_provider.dart
+++ b/lib/features/decks/presentation/providers/deck_detail_provider.dart
@@ -2,6 +2,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lapse/core/sync/sync_service.dart';
 import 'package:lapse/features/cards/data/card_repository_provider.dart';
 import 'package:lapse/features/decks/data/deck_repository_provider.dart';
+import 'package:lapse/features/decks/domain/deck.dart';
 import 'package:lapse/features/decks/presentation/providers/deck_detail_state.dart';
 import 'package:lapse/features/decks/presentation/providers/deck_list_provider.dart';
 
@@ -94,6 +95,30 @@ class DeckDetailNotifier extends AsyncNotifier<DeckDetailState> {
     await ref.read(deckRepositoryProvider).delete(childDeckId);
     ref.invalidateSelf();
     ref.invalidate(deckListProvider);
+  }
+
+  Future<void> moveChildDeck(String childDeckId, String? newParentId) async {
+    final deckRepo = ref.read(deckRepositoryProvider);
+    final deck = await deckRepo.getById(childDeckId);
+    if (deck == null) return;
+
+    await deckRepo.update(
+      deck.copyWith(parentId: Optional.value(newParentId)),
+    );
+    ref.invalidateSelf();
+    ref.invalidate(deckListProvider);
+    ref.read(syncServiceProvider.notifier).schedulePush();
+  }
+
+  Future<void> moveCard(String cardId, String newDeckId) async {
+    final cardRepo = ref.read(cardRepositoryProvider);
+    final card = await cardRepo.getById(cardId);
+    if (card == null) return;
+
+    await cardRepo.update(card.copyWith(deckId: newDeckId));
+    ref.invalidateSelf();
+    ref.invalidate(deckListProvider);
+    ref.read(syncServiceProvider.notifier).schedulePush();
   }
 
   Future<void> deleteCard(String cardId) async {

--- a/lib/features/decks/presentation/screens/deck_detail_screen.dart
+++ b/lib/features/decks/presentation/screens/deck_detail_screen.dart
@@ -8,6 +8,7 @@ import 'package:lapse/core/theme/spacing.dart';
 import 'package:lapse/core/widgets/app_snack_bar.dart';
 import 'package:lapse/core/widgets/confirm_dialog.dart';
 import 'package:lapse/core/widgets/context_menu_region.dart';
+import 'package:lapse/core/widgets/deck_picker_dialog.dart';
 import 'package:lapse/core/widgets/empty_state_widget.dart';
 import 'package:lapse/core/widgets/loading_indicator.dart';
 import 'package:lapse/features/cards/domain/flashcard.dart';
@@ -196,15 +197,47 @@ class _DeckDetailScreenState extends ConsumerState<DeckDetailScreen>
               .deleteChildDeck(deck.deckId);
           break;
         case ContextMenuAction.move:
+          final deckRepo = ref.read(deckRepositoryProvider);
+          final allDecks = await deckRepo.getAll();
+          final excludeIds =
+              (await deckRepo.getDescendantIds(deck.deckId)).toSet();
+
           if (!mounted) return;
-          AppSnackBar.show(context, 'Move action is coming soon',
-);
+          final targetId = await DeckPickerDialog.show(
+            context: context,
+            decks: allDecks,
+            excludeIds: excludeIds,
+            currentParentId: deck.parentId,
+          );
+          if (targetId == null || !mounted) return;
+
+          final newParentId = targetId.isEmpty ? null : targetId;
+          if (newParentId == deck.parentId) return;
+
+          final nameConflict = await deckRepo.nameExistsAtLevel(
+            name: deck.deckName,
+            parentId: newParentId,
+            excludeDeckId: deck.deckId,
+          );
+          if (nameConflict) {
+            if (!mounted) return;
+            AppSnackBar.show(
+              context,
+              'A deck named "${deck.deckName}" already exists there',
+            );
+            return;
+          }
+
+          await ref
+              .read(deckDetailProvider(widget.deckId).notifier)
+              .moveChildDeck(deck.deckId, newParentId);
+          if (!mounted) return;
+          AppSnackBar.show(context, 'Moved "${deck.deckName}"');
           break;
       }
     } catch (e) {
       if (mounted) {
-        AppSnackBar.show(context, 'Action failed: $e',
-);
+        AppSnackBar.show(context, 'Action failed: $e');
       }
     }
   }
@@ -235,15 +268,30 @@ class _DeckDetailScreenState extends ConsumerState<DeckDetailScreen>
               .deleteCard(card.cardId);
           break;
         case ContextMenuAction.move:
+          final deckRepo = ref.read(deckRepositoryProvider);
+          final allDecks = await deckRepo.getAll();
+
           if (!mounted) return;
-          AppSnackBar.show(context, 'Move action is coming soon',
-);
+          final targetId = await DeckPickerDialog.show(
+            context: context,
+            decks: allDecks,
+            excludeIds: const <String>{},
+            currentParentId: card.deckId,
+            showRoot: false,
+          );
+          if (targetId == null || !mounted) return;
+          if (targetId == card.deckId) return;
+
+          await ref
+              .read(deckDetailProvider(widget.deckId).notifier)
+              .moveCard(card.cardId, targetId);
+          if (!mounted) return;
+          AppSnackBar.show(context, 'Card moved');
           break;
       }
     } catch (e) {
       if (mounted) {
-        AppSnackBar.show(context, 'Action failed: $e',
-);
+        AppSnackBar.show(context, 'Action failed: $e');
       }
     }
   }

--- a/lib/features/decks/presentation/screens/deck_list_screen.dart
+++ b/lib/features/decks/presentation/screens/deck_list_screen.dart
@@ -7,6 +7,9 @@ import 'package:lapse/core/theme/spacing.dart';
 import 'package:lapse/core/widgets/app_snack_bar.dart';
 import 'package:lapse/core/widgets/confirm_dialog.dart';
 import 'package:lapse/core/widgets/context_menu_region.dart';
+import 'package:lapse/core/widgets/deck_picker_dialog.dart';
+import 'package:lapse/core/sync/sync_service.dart';
+import 'package:lapse/features/decks/data/deck_repository_provider.dart';
 import 'package:lapse/core/widgets/dev_drawer.dart';
 import 'package:lapse/features/decks/domain/deck.dart';
 import 'package:lapse/features/decks/domain/deck_with_counts.dart';
@@ -125,9 +128,44 @@ class _DeckList extends ConsumerWidget {
           await ref.read(deckListProvider.notifier).deleteDeck(deck.deckId);
           break;
         case ContextMenuAction.move:
+          final deckRepo = ref.read(deckRepositoryProvider);
+          final allDecks = await deckRepo.getAll();
+          final excludeIds =
+              (await deckRepo.getDescendantIds(deck.deckId)).toSet();
+
           if (!context.mounted) return;
-          AppSnackBar.show(context, 'Move action is coming soon',
-);
+          final targetId = await DeckPickerDialog.show(
+            context: context,
+            decks: allDecks,
+            excludeIds: excludeIds,
+            currentParentId: deck.parentId,
+          );
+          if (targetId == null || !context.mounted) return;
+
+          final newParentId = targetId.isEmpty ? null : targetId;
+          if (newParentId == deck.parentId) return;
+
+          final nameConflict = await deckRepo.nameExistsAtLevel(
+            name: deck.deckName,
+            parentId: newParentId,
+            excludeDeckId: deck.deckId,
+          );
+          if (nameConflict) {
+            if (!context.mounted) return;
+            AppSnackBar.show(
+              context,
+              'A deck named "${deck.deckName}" already exists there',
+            );
+            return;
+          }
+
+          final deckToMove =
+              deck.copyWith(parentId: Optional.value(newParentId));
+          await deckRepo.update(deckToMove);
+          ref.invalidate(deckListProvider);
+          ref.read(syncServiceProvider.notifier).schedulePush();
+          if (!context.mounted) return;
+          AppSnackBar.show(context, 'Moved "${deck.deckName}"');
           break;
       }
     } catch (e) {


### PR DESCRIPTION
## Summary
- **#116** — Fix long-press context menu opening at widget center instead of touch point (onLongPress → onLongPressStart)
- **#117** — Add PopupMenuThemeData (rounded corners, outline border, elevated surface), add muted icons to all menu items
- **#156 (partial)** — Implement single-item move via new DeckPickerDialog (deck tree picker with circular-ref prevention, name conflict checks, current-location graying). Multi-select/bulk ops deferred to separate issue.
- **Bonus** — Fix dev drawer snackbar crash on rapid tap (Navigator.pop → closeDrawer), add placeholder Import/Export buttons in dev drawer for #150 testing