### PR TITLE
feat: simplify due-card reminder scheduling

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
     <application
         android:label="lapse"
         android:name="${applicationName}"

--- a/lib/features/cards/data/card_repository.dart
+++ b/lib/features/cards/data/card_repository.dart
@@ -144,6 +144,27 @@ class CardRepository {
     };
   }
 
+  /// Returns distinct calendar days that have non-deleted cards due on or
+  /// after the provided day (defaults to today).
+  Future<List<DateTime>> getDistinctDueDates({DateTime? fromDay}) async {
+    final db = await _dbHelper.database;
+    final base = fromDay ?? DateTime.now();
+    final start = DateTime(
+      base.year,
+      base.month,
+      base.day,
+    );
+    final rows = await db.rawQuery(
+      'SELECT DISTINCT DATE(${DatabaseConstants.colDueDate}) AS day '
+      'FROM ${DatabaseConstants.tableCards} '
+      'WHERE ${DatabaseConstants.colIsDeleted} = 0 '
+      'AND DATE(${DatabaseConstants.colDueDate}) >= DATE(?) '
+      'ORDER BY day ASC',
+      [start.toUtc().toIso8601String()],
+    );
+    return rows.map((row) => DateTime.parse(row['day'] as String)).toList();
+  }
+
   /// Returns true if a non-deleted card with [front] text exists in [deckId].
   /// Use [excludeCardId] to skip self when editing.
   Future<bool> frontExistsInDeck({

--- a/lib/features/notifications/application/due_reminder_scheduler.dart
+++ b/lib/features/notifications/application/due_reminder_scheduler.dart
@@ -1,0 +1,98 @@
+import 'package:lapse/features/notifications/data/notification_prefs_store.dart';
+import 'package:lapse/features/notifications/application/notification_service.dart';
+import 'package:lapse/features/cards/data/card_repository.dart';
+
+class DueReminderScheduler {
+  static const int maxScheduledReminders = 30;
+
+  final CardRepository _cardRepository;
+  final NotificationService _notificationService;
+  final NotificationPrefsStore _prefsStore;
+  final DateTime Function() _now;
+
+  DueReminderScheduler({
+    required CardRepository cardRepository,
+    required NotificationService notificationService,
+    required NotificationPrefsStore prefsStore,
+    DateTime Function()? now,
+  }) : _cardRepository = cardRepository,
+       _notificationService = notificationService,
+       _prefsStore = prefsStore,
+       _now = now ?? DateTime.now;
+
+  Future<void> rescheduleAll() async {
+    await _notificationService.initialize();
+
+    final settings = await _prefsStore.load();
+    final existingIds = await _prefsStore.loadScheduledDueReminderIds();
+    await _notificationService.cancelDueReminders(existingIds);
+    await _prefsStore.saveScheduledDueReminderIds(const <int>[]);
+
+    if (!settings.enabled) return;
+
+    final now = _now();
+    final today = _startOfDay(now);
+    final sortedDays = await _cardRepository.getDistinctDueDates(fromDay: today);
+    if (sortedDays.isEmpty) return;
+
+    sortedDays.sort((a, b) => a.compareTo(b));
+
+    final plans = <_ReminderPlan>[];
+    for (final day in sortedDays) {
+      final fireAt = DateTime(
+        day.year,
+        day.month,
+        day.day,
+        settings.reminderHour,
+        settings.reminderMinute,
+      );
+      if (!fireAt.isAfter(now.add(const Duration(seconds: 5)))) continue;
+
+      plans.add(
+        _ReminderPlan(
+          id: _notificationId(day),
+          fireAt: fireAt,
+          title: 'Cards ready to review',
+          body: 'You have cards to review today.',
+        ),
+      );
+    }
+
+    plans.sort((a, b) => a.fireAt.compareTo(b.fireAt));
+
+    final scheduledIds = <int>[];
+    for (final plan in plans.take(maxScheduledReminders)) {
+      await _notificationService.scheduleDueReminder(
+        id: plan.id,
+        title: plan.title,
+        body: plan.body,
+        whenLocal: plan.fireAt,
+      );
+      scheduledIds.add(plan.id);
+    }
+
+    await _prefsStore.saveScheduledDueReminderIds(scheduledIds);
+  }
+
+  static DateTime _startOfDay(DateTime value) {
+    return DateTime(value.year, value.month, value.day);
+  }
+
+  static int _notificationId(DateTime day) {
+    return day.year * 10000 + day.month * 100 + day.day;
+  }
+}
+
+class _ReminderPlan {
+  final int id;
+  final DateTime fireAt;
+  final String title;
+  final String body;
+
+  const _ReminderPlan({
+    required this.id,
+    required this.fireAt,
+    required this.title,
+    required this.body,
+  });
+}

--- a/lib/features/notifications/application/notification_service.dart
+++ b/lib/features/notifications/application/notification_service.dart
@@ -1,0 +1,133 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:flutter_timezone/flutter_timezone.dart';
+import 'package:timezone/data/latest.dart' as tz_data;
+import 'package:timezone/timezone.dart' as tz;
+
+class NotificationService {
+  static const String dueChannelId = 'due_reminders';
+  static const String dueChannelName = 'Due reminders';
+  static const String dueChannelDescription =
+      'Reminders for cards due in 1 week, 1 day, and today.';
+
+  final FlutterLocalNotificationsPlugin _plugin;
+  bool _initialized = false;
+
+  NotificationService({FlutterLocalNotificationsPlugin? plugin})
+    : _plugin = plugin ?? FlutterLocalNotificationsPlugin();
+
+  Future<void> initialize() async {
+    if (_initialized) return;
+    tz_data.initializeTimeZones();
+
+    try {
+      final localTimezone = await FlutterTimezone.getLocalTimezone();
+      tz.setLocalLocation(tz.getLocation(localTimezone));
+    } catch (_) {
+      tz.setLocalLocation(tz.getLocation('UTC'));
+    }
+
+    const initSettings = InitializationSettings(
+      android: AndroidInitializationSettings('@mipmap/ic_launcher'),
+      iOS: DarwinInitializationSettings(
+        requestAlertPermission: false,
+        requestBadgePermission: false,
+        requestSoundPermission: false,
+      ),
+      macOS: DarwinInitializationSettings(
+        requestAlertPermission: false,
+        requestBadgePermission: false,
+        requestSoundPermission: false,
+      ),
+    );
+
+    await _plugin.initialize(initSettings);
+    _initialized = true;
+  }
+
+  Future<bool> requestPermissions() async {
+    await initialize();
+    var granted = true;
+
+    final android = _plugin
+        .resolvePlatformSpecificImplementation<
+          AndroidFlutterLocalNotificationsPlugin
+        >();
+    final ios = _plugin
+        .resolvePlatformSpecificImplementation<
+          IOSFlutterLocalNotificationsPlugin
+        >();
+    final macos = _plugin
+        .resolvePlatformSpecificImplementation<
+          MacOSFlutterLocalNotificationsPlugin
+        >();
+
+    if (android != null) {
+      final androidGranted = await android.requestNotificationsPermission();
+      granted = granted && (androidGranted ?? true);
+    }
+    if (ios != null) {
+      final iosGranted = await ios.requestPermissions(
+        alert: true,
+        badge: true,
+        sound: true,
+      );
+      granted = granted && (iosGranted ?? false);
+    }
+    if (macos != null) {
+      final macGranted = await macos.requestPermissions(
+        alert: true,
+        badge: true,
+        sound: true,
+      );
+      granted = granted && (macGranted ?? false);
+    }
+    return granted;
+  }
+
+  Future<void> cancelDueReminders(Iterable<int> ids) async {
+    await initialize();
+    for (final id in ids) {
+      await _plugin.cancel(id);
+    }
+  }
+
+  Future<void> scheduleDueReminder({
+    required int id,
+    required String title,
+    required String body,
+    required DateTime whenLocal,
+  }) async {
+    await initialize();
+    if (!whenLocal.isAfter(DateTime.now())) return;
+
+    final details = NotificationDetails(
+      android: const AndroidNotificationDetails(
+        dueChannelId,
+        dueChannelName,
+        channelDescription: dueChannelDescription,
+        importance: Importance.defaultImportance,
+        priority: Priority.defaultPriority,
+      ),
+      iOS: const DarwinNotificationDetails(),
+      macOS: const DarwinNotificationDetails(),
+    );
+
+    try {
+      await _plugin.zonedSchedule(
+        id,
+        title,
+        body,
+        tz.TZDateTime.from(whenLocal, tz.local),
+        details,
+        androidScheduleMode: AndroidScheduleMode.inexactAllowWhileIdle,
+      );
+    } on UnimplementedError {
+      if (kDebugMode) {
+        debugPrint(
+          '[NotificationService] zonedSchedule unsupported on this platform.',
+        );
+      }
+    }
+  }
+}

--- a/lib/features/notifications/data/notification_prefs_store.dart
+++ b/lib/features/notifications/data/notification_prefs_store.dart
@@ -1,0 +1,51 @@
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:lapse/features/notifications/domain/notification_settings.dart';
+
+class NotificationPrefsStore {
+  static const _kEnabled = 'notifications.enabled';
+  static const _kDueToday = 'notifications.due_today';
+  static const _kOneDay = 'notifications.one_day';
+  static const _kOneWeek = 'notifications.one_week';
+  static const _kHour = 'notifications.hour';
+  static const _kMinute = 'notifications.minute';
+  static const _kScheduledIds = 'notifications.scheduled_ids';
+
+  Future<NotificationSettings> load() async {
+    final prefs = await SharedPreferences.getInstance();
+    final defaults = const NotificationSettings.defaults();
+    return NotificationSettings(
+      enabled: prefs.getBool(_kEnabled) ?? defaults.enabled,
+      remindDueToday: prefs.getBool(_kDueToday) ?? defaults.remindDueToday,
+      remindOneDayBefore:
+          prefs.getBool(_kOneDay) ?? defaults.remindOneDayBefore,
+      remindOneWeekBefore:
+          prefs.getBool(_kOneWeek) ?? defaults.remindOneWeekBefore,
+      reminderHour: prefs.getInt(_kHour) ?? defaults.reminderHour,
+      reminderMinute: prefs.getInt(_kMinute) ?? defaults.reminderMinute,
+    );
+  }
+
+  Future<void> save(NotificationSettings settings) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_kEnabled, settings.enabled);
+    await prefs.setBool(_kDueToday, settings.remindDueToday);
+    await prefs.setBool(_kOneDay, settings.remindOneDayBefore);
+    await prefs.setBool(_kOneWeek, settings.remindOneWeekBefore);
+    await prefs.setInt(_kHour, settings.reminderHour);
+    await prefs.setInt(_kMinute, settings.reminderMinute);
+  }
+
+  Future<List<int>> loadScheduledDueReminderIds() async {
+    final prefs = await SharedPreferences.getInstance();
+    final raw = prefs.getStringList(_kScheduledIds) ?? const <String>[];
+    return raw.map(int.tryParse).whereType<int>().toList();
+  }
+
+  Future<void> saveScheduledDueReminderIds(List<int> ids) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setStringList(
+      _kScheduledIds,
+      ids.map((id) => id.toString()).toList(),
+    );
+  }
+}

--- a/lib/features/notifications/domain/notification_settings.dart
+++ b/lib/features/notifications/domain/notification_settings.dart
@@ -1,0 +1,43 @@
+class NotificationSettings {
+  final bool enabled;
+  final bool remindDueToday;
+  final bool remindOneDayBefore;
+  final bool remindOneWeekBefore;
+  final int reminderHour;
+  final int reminderMinute;
+
+  const NotificationSettings({
+    required this.enabled,
+    required this.remindDueToday,
+    required this.remindOneDayBefore,
+    required this.remindOneWeekBefore,
+    required this.reminderHour,
+    required this.reminderMinute,
+  });
+
+  const NotificationSettings.defaults()
+    : enabled = false,
+      remindDueToday = true,
+      remindOneDayBefore = true,
+      remindOneWeekBefore = true,
+      reminderHour = 9,
+      reminderMinute = 0;
+
+  NotificationSettings copyWith({
+    bool? enabled,
+    bool? remindDueToday,
+    bool? remindOneDayBefore,
+    bool? remindOneWeekBefore,
+    int? reminderHour,
+    int? reminderMinute,
+  }) {
+    return NotificationSettings(
+      enabled: enabled ?? this.enabled,
+      remindDueToday: remindDueToday ?? this.remindDueToday,
+      remindOneDayBefore: remindOneDayBefore ?? this.remindOneDayBefore,
+      remindOneWeekBefore: remindOneWeekBefore ?? this.remindOneWeekBefore,
+      reminderHour: reminderHour ?? this.reminderHour,
+      reminderMinute: reminderMinute ?? this.reminderMinute,
+    );
+  }
+}

--- a/lib/features/notifications/presentation/providers/notification_providers.dart
+++ b/lib/features/notifications/presentation/providers/notification_providers.dart
@@ -1,0 +1,83 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:lapse/features/cards/data/card_repository_provider.dart';
+import 'package:lapse/features/notifications/application/due_reminder_scheduler.dart';
+import 'package:lapse/features/notifications/application/notification_service.dart';
+import 'package:lapse/features/notifications/data/notification_prefs_store.dart';
+import 'package:lapse/features/notifications/domain/notification_settings.dart';
+
+final notificationServiceProvider = Provider<NotificationService>((ref) {
+  return NotificationService();
+});
+
+final notificationPrefsStoreProvider = Provider<NotificationPrefsStore>((ref) {
+  return NotificationPrefsStore();
+});
+
+final dueReminderSchedulerProvider = Provider<DueReminderScheduler>((ref) {
+  return DueReminderScheduler(
+    cardRepository: ref.read(cardRepositoryProvider),
+    notificationService: ref.read(notificationServiceProvider),
+    prefsStore: ref.read(notificationPrefsStoreProvider),
+  );
+});
+
+final notificationBootstrapProvider = FutureProvider<void>((ref) async {
+  await ref.read(notificationServiceProvider).initialize();
+  await ref.read(dueReminderSchedulerProvider).rescheduleAll();
+});
+
+final notificationSettingsProvider =
+    AsyncNotifierProvider<NotificationSettingsNotifier, NotificationSettings>(
+      NotificationSettingsNotifier.new,
+    );
+
+class NotificationSettingsNotifier extends AsyncNotifier<NotificationSettings> {
+  @override
+  Future<NotificationSettings> build() async {
+    return ref.read(notificationPrefsStoreProvider).load();
+  }
+
+  Future<bool> setEnabled(bool enabled) async {
+    final current = _current;
+    if (enabled) {
+      final granted = await ref
+          .read(notificationServiceProvider)
+          .requestPermissions();
+      if (!granted) return false;
+    }
+    final next = current.copyWith(enabled: enabled);
+    await _persistAndReschedule(next);
+    return true;
+  }
+
+  Future<void> setReminderTime({required int hour, required int minute}) async {
+    final current = _current;
+    final next = current.copyWith(reminderHour: hour, reminderMinute: minute);
+    await _persistAndReschedule(next);
+  }
+
+  Future<void> setRemindDueToday(bool value) async {
+    final next = _current.copyWith(remindDueToday: value);
+    await _persistAndReschedule(next);
+  }
+
+  Future<void> setRemindOneDayBefore(bool value) async {
+    final next = _current.copyWith(remindOneDayBefore: value);
+    await _persistAndReschedule(next);
+  }
+
+  Future<void> setRemindOneWeekBefore(bool value) async {
+    final next = _current.copyWith(remindOneWeekBefore: value);
+    await _persistAndReschedule(next);
+  }
+
+  NotificationSettings get _current {
+    return state.asData?.value ?? const NotificationSettings.defaults();
+  }
+
+  Future<void> _persistAndReschedule(NotificationSettings next) async {
+    await ref.read(notificationPrefsStoreProvider).save(next);
+    state = AsyncData(next);
+    await ref.read(dueReminderSchedulerProvider).rescheduleAll();
+  }
+}

--- a/lib/features/settings/presentation/screens/settings_screen.dart
+++ b/lib/features/settings/presentation/screens/settings_screen.dart
@@ -16,6 +16,7 @@ import '../../../../core/theme/spacing.dart';
 import '../../../../core/widgets/app_snack_bar.dart';
 import '../../../../core/widgets/confirm_dialog.dart';
 import '../../../auth/application/auth_service.dart';
+import '../../../notifications/presentation/providers/notification_providers.dart';
 
 /// Obsidian-inspired settings screen with sectioned layout.
 ///
@@ -1239,27 +1240,169 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
     );
   }
 
-  // ─── Notifications section (placeholder) ───────────────────────────────
+  // ─── Notifications section ───────────────────────────────────────────────
 
   Widget _buildNotificationsSection() {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        _buildSectionHeader('Notifications', _sections[3].key),
-        _SettingsTile(
-          leading: const Icon(
-            Icons.notifications_outlined,
-            color: AppColors.textSecondary,
+    final settingsAsync = ref.watch(notificationSettingsProvider);
+    final notifier = ref.read(notificationSettingsProvider.notifier);
+
+    return settingsAsync.when(
+      loading: () => Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          _buildSectionHeader('Notifications', _sections[3].key),
+          const _SettingsTile(
+            leading: Icon(
+              Icons.notifications_outlined,
+              color: AppColors.textSecondary,
+            ),
+            title: 'Loading notification settings...',
+            trailing: SizedBox(
+              width: 20,
+              height: 20,
+              child: CircularProgressIndicator(strokeWidth: 2),
+            ),
           ),
-          title: 'Push notifications',
-          subtitle: 'Coming soon',
-          trailing: Switch(
-            value: false,
-            onChanged: (_) =>
-                _showError('Push notifications not yet implemented.'),
+        ],
+      ),
+      error: (error, _) => Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          _buildSectionHeader('Notifications', _sections[3].key),
+          _SettingsTile(
+            leading: const Icon(Icons.error_outline, color: AppColors.error),
+            title: 'Failed to load notification settings',
+            subtitle: '$error',
+            trailing: IconButton(
+              icon: const Icon(Icons.refresh, color: AppColors.textSecondary),
+              onPressed: () => ref.invalidate(notificationSettingsProvider),
+            ),
           ),
-        ),
-      ],
+        ],
+      ),
+      data: (settings) {
+        final reminderTime = TimeOfDay(
+          hour: settings.reminderHour,
+          minute: settings.reminderMinute,
+        );
+        final reminderTimeLabel = MaterialLocalizations.of(
+          context,
+        ).formatTimeOfDay(reminderTime);
+
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            _buildSectionHeader('Notifications', _sections[3].key),
+            _SettingsTile(
+              leading: const Icon(
+                Icons.notifications_outlined,
+                color: AppColors.textSecondary,
+              ),
+              title: 'Due card reminders',
+              subtitle:
+                  'Get alerts for cards due today, tomorrow, and in 1 week',
+              trailing: Switch(
+                value: settings.enabled,
+                onChanged: (value) async {
+                  final ok = await notifier.setEnabled(value);
+                  if (!ok && mounted) {
+                    _showError(
+                      'Notification permission denied. Enable it in system settings.',
+                    );
+                  }
+                },
+              ),
+            ),
+            const SizedBox(height: Spacing.md),
+            _SettingsTile(
+              leading: const Icon(
+                Icons.schedule_outlined,
+                color: AppColors.textSecondary,
+              ),
+              title: 'Reminder time',
+              subtitle: settings.enabled
+                  ? 'When reminders should appear'
+                  : 'Enable reminders to set a time',
+              trailing: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Text(
+                    reminderTimeLabel,
+                    style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                      color: settings.enabled
+                          ? AppColors.textSecondary
+                          : AppColors.textTertiary,
+                    ),
+                  ),
+                  const SizedBox(width: 6),
+                  const Icon(
+                    Icons.chevron_right,
+                    color: AppColors.textTertiary,
+                  ),
+                ],
+              ),
+              onTap: settings.enabled
+                  ? () async {
+                      final picked = await showTimePicker(
+                        context: context,
+                        initialTime: reminderTime,
+                      );
+                      if (picked == null) return;
+                      await notifier.setReminderTime(
+                        hour: picked.hour,
+                        minute: picked.minute,
+                      );
+                    }
+                  : null,
+            ),
+            const SizedBox(height: Spacing.md),
+            _SettingsTile(
+              leading: const Icon(
+                Icons.today_outlined,
+                color: AppColors.textSecondary,
+              ),
+              title: 'Due today',
+              subtitle: 'Notify when cards are due today',
+              trailing: Switch(
+                value: settings.remindDueToday,
+                onChanged: settings.enabled
+                    ? (value) => notifier.setRemindDueToday(value)
+                    : null,
+              ),
+            ),
+            const SizedBox(height: Spacing.md),
+            _SettingsTile(
+              leading: const Icon(
+                Icons.event_available_outlined,
+                color: AppColors.textSecondary,
+              ),
+              title: '1 day before',
+              subtitle: 'Notify one day before cards are due',
+              trailing: Switch(
+                value: settings.remindOneDayBefore,
+                onChanged: settings.enabled
+                    ? (value) => notifier.setRemindOneDayBefore(value)
+                    : null,
+              ),
+            ),
+            const SizedBox(height: Spacing.md),
+            _SettingsTile(
+              leading: const Icon(
+                Icons.date_range_outlined,
+                color: AppColors.textSecondary,
+              ),
+              title: '1 week before',
+              subtitle: 'Notify one week before cards are due',
+              trailing: Switch(
+                value: settings.remindOneWeekBefore,
+                onChanged: settings.enabled
+                    ? (value) => notifier.setRemindOneWeekBefore(value)
+                    : null,
+              ),
+            ),
+          ],
+        );
+      },
     );
   }
 

--- a/lib/features/study/presentation/screens/study_session_screen.dart
+++ b/lib/features/study/presentation/screens/study_session_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -16,6 +18,7 @@ import 'package:lapse/features/study/domain/rating.dart';
 import 'package:lapse/features/study/data/review_repository_provider.dart';
 import 'package:lapse/features/study/application/study_session_service.dart';
 import 'package:lapse/core/sync/sync_service.dart';
+import 'package:lapse/features/notifications/presentation/providers/notification_providers.dart';
 import 'package:lapse/features/study/domain/study_session.dart';
 import 'package:lapse/features/study/presentation/widgets/card_stack.dart';
 import 'package:lapse/features/study/presentation/widgets/flip_card.dart';
@@ -886,6 +889,7 @@ class _StudySessionScreenState extends ConsumerState<StudySessionScreen>
               onPressed: () async {
                 await _flushPendingWrite();
                 _invalidateDeckProviders();
+                unawaited(ref.read(dueReminderSchedulerProvider).rescheduleAll());
                 if (mounted) context.pop();
               },
               child: const Text('Done'),
@@ -947,6 +951,7 @@ class _StudySessionScreenState extends ConsumerState<StudySessionScreen>
     if (shouldExit == true && context.mounted) {
       await _flushPendingWrite();
       _invalidateDeckProviders();
+      unawaited(ref.read(dueReminderSchedulerProvider).rescheduleAll());
       if (context.mounted) context.pop();
     }
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -6,6 +6,7 @@ import 'package:toastification/toastification.dart';
 import 'package:sqflite_common_ffi/sqflite_ffi.dart';
 import 'package:window_manager/window_manager.dart';
 import 'core/database/database_helper.dart';
+import 'features/notifications/presentation/providers/notification_providers.dart';
 import 'core/routing/app_router.dart';
 import 'core/routing/page_transitions.dart';
 import 'core/supabase/supabase_config.dart';
@@ -81,6 +82,8 @@ class LapseApp extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     // Eagerly initialize sync service so lifecycle listener starts immediately.
     ref.watch(syncServiceProvider);
+    // Schedule due reminders when the app starts.
+    ref.watch(notificationBootstrapProvider);
 
     return ToastificationWrapper(
       config: ToastificationConfig(

--- a/linux/flutter/generated_plugin_registrant.cc
+++ b/linux/flutter/generated_plugin_registrant.cc
@@ -6,12 +6,16 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <flutter_timezone/flutter_timezone_plugin.h>
 #include <gtk/gtk_plugin.h>
 #include <screen_retriever_linux/screen_retriever_linux_plugin.h>
 #include <url_launcher_linux/url_launcher_plugin.h>
 #include <window_manager/window_manager_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
+  g_autoptr(FlPluginRegistrar) flutter_timezone_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "FlutterTimezonePlugin");
+  flutter_timezone_plugin_register_with_registrar(flutter_timezone_registrar);
   g_autoptr(FlPluginRegistrar) gtk_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "GtkPlugin");
   gtk_plugin_register_with_registrar(gtk_registrar);

--- a/linux/flutter/generated_plugins.cmake
+++ b/linux/flutter/generated_plugins.cmake
@@ -3,6 +3,7 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  flutter_timezone
   gtk
   screen_retriever_linux
   url_launcher_linux

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -7,6 +7,8 @@ import Foundation
 
 import app_links
 import connectivity_plus
+import flutter_local_notifications
+import flutter_timezone
 import package_info_plus
 import screen_retriever_macos
 import shared_preferences_foundation
@@ -17,6 +19,8 @@ import window_manager
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   AppLinksMacosPlugin.register(with: registry.registrar(forPlugin: "AppLinksMacosPlugin"))
   ConnectivityPlusPlugin.register(with: registry.registrar(forPlugin: "ConnectivityPlusPlugin"))
+  FlutterLocalNotificationsPlugin.register(with: registry.registrar(forPlugin: "FlutterLocalNotificationsPlugin"))
+  FlutterTimezonePlugin.register(with: registry.registrar(forPlugin: "FlutterTimezonePlugin"))
   FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))
   ScreenRetrieverMacosPlugin.register(with: registry.registrar(forPlugin: "ScreenRetrieverMacosPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))

--- a/macos/Podfile.lock
+++ b/macos/Podfile.lock
@@ -3,6 +3,10 @@ PODS:
     - FlutterMacOS
   - connectivity_plus (0.0.1):
     - FlutterMacOS
+  - flutter_local_notifications (0.0.1):
+    - FlutterMacOS
+  - flutter_timezone (0.1.0):
+    - FlutterMacOS
   - FlutterMacOS (1.0.0)
   - package_info_plus (0.0.1):
     - FlutterMacOS
@@ -22,6 +26,8 @@ PODS:
 DEPENDENCIES:
   - app_links (from `Flutter/ephemeral/.symlinks/plugins/app_links/macos`)
   - connectivity_plus (from `Flutter/ephemeral/.symlinks/plugins/connectivity_plus/macos`)
+  - flutter_local_notifications (from `Flutter/ephemeral/.symlinks/plugins/flutter_local_notifications/macos`)
+  - flutter_timezone (from `Flutter/ephemeral/.symlinks/plugins/flutter_timezone/macos`)
   - FlutterMacOS (from `Flutter/ephemeral`)
   - package_info_plus (from `Flutter/ephemeral/.symlinks/plugins/package_info_plus/macos`)
   - screen_retriever_macos (from `Flutter/ephemeral/.symlinks/plugins/screen_retriever_macos/macos`)
@@ -35,6 +41,10 @@ EXTERNAL SOURCES:
     :path: Flutter/ephemeral/.symlinks/plugins/app_links/macos
   connectivity_plus:
     :path: Flutter/ephemeral/.symlinks/plugins/connectivity_plus/macos
+  flutter_local_notifications:
+    :path: Flutter/ephemeral/.symlinks/plugins/flutter_local_notifications/macos
+  flutter_timezone:
+    :path: Flutter/ephemeral/.symlinks/plugins/flutter_timezone/macos
   FlutterMacOS:
     :path: Flutter/ephemeral
   package_info_plus:
@@ -53,6 +63,8 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   app_links: 05a6ec2341985eb05e9f97dc63f5837c39895c3f
   connectivity_plus: 4adf20a405e25b42b9c9f87feff8f4b6fde18a4e
+  flutter_local_notifications: 4bf37a31afde695b56091b4ae3e4d9c7a7e6cda0
+  flutter_timezone: d59eea86178cbd7943cd2431cc2eaa9850f935d8
   FlutterMacOS: d0db08ddef1a9af05a5ec4b724367152bb0500b1
   package_info_plus: f0052d280d17aa382b932f399edf32507174e870
   screen_retriever_macos: 452e51764a9e1cdb74b3c541238795849f21557f

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -294,6 +294,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.0.0"
+  flutter_local_notifications:
+    dependency: "direct main"
+    description:
+      name: flutter_local_notifications
+      sha256: "19ffb0a8bb7407875555e5e98d7343a633bb73707bae6c6a5f37c90014077875"
+      url: "https://pub.dev"
+    source: hosted
+    version: "19.5.0"
+  flutter_local_notifications_linux:
+    dependency: transitive
+    description:
+      name: flutter_local_notifications_linux
+      sha256: e3c277b2daab8e36ac5a6820536668d07e83851aeeb79c446e525a70710770a5
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.0.0"
+  flutter_local_notifications_platform_interface:
+    dependency: transitive
+    description:
+      name: flutter_local_notifications_platform_interface
+      sha256: "277d25d960c15674ce78ca97f57d0bae2ee401c844b6ac80fcd972a9c99d09fe"
+      url: "https://pub.dev"
+    source: hosted
+    version: "9.1.0"
+  flutter_local_notifications_windows:
+    dependency: transitive
+    description:
+      name: flutter_local_notifications_windows
+      sha256: "8d658f0d367c48bd420e7cf2d26655e2d1130147bca1eea917e576ca76668aaf"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.3"
   flutter_markdown_plus:
     dependency: "direct main"
     description:
@@ -323,6 +355,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_timezone:
+    dependency: "direct main"
+    description:
+      name: flutter_timezone
+      sha256: "13b2109ad75651faced4831bf262e32559e44aa549426eab8a597610d385d934"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.1.1"
   flutter_web_plugins:
     dependency: transitive
     description: flutter
@@ -448,6 +488,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.5"
+  js:
+    dependency: transitive
+    description:
+      name: js
+      sha256: "53385261521cc4a0c4658fd0ad07a7d14591cf8fc33abbceae306ddb974888dc"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.2"
   json_annotation:
     dependency: transitive
     description:
@@ -1093,6 +1141,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.6.16"
+  timezone:
+    dependency: "direct main"
+    description:
+      name: timezone
+      sha256: dd14a3b83cfd7cb19e7888f1cbc20f258b8d71b54c06f79ac585f14093a287d1
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.10.1"
   toastification:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -53,6 +53,9 @@ dependencies:
   package_info_plus: ^9.0.0
   connectivity_plus: ^7.0.0
   toastification: ^3.0.3
+  flutter_local_notifications: ^19.2.1
+  timezone: ^0.10.0
+  flutter_timezone: ^4.1.1
 
 dev_dependencies:
   flutter_test:

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -8,6 +8,7 @@
 
 #include <app_links/app_links_plugin_c_api.h>
 #include <connectivity_plus/connectivity_plus_windows_plugin.h>
+#include <flutter_timezone/flutter_timezone_plugin_c_api.h>
 #include <screen_retriever_windows/screen_retriever_windows_plugin_c_api.h>
 #include <url_launcher_windows/url_launcher_windows.h>
 #include <window_manager/window_manager_plugin.h>
@@ -17,6 +18,8 @@ void RegisterPlugins(flutter::PluginRegistry* registry) {
       registry->GetRegistrarForPlugin("AppLinksPluginCApi"));
   ConnectivityPlusWindowsPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("ConnectivityPlusWindowsPlugin"));
+  FlutterTimezonePluginCApiRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("FlutterTimezonePluginCApi"));
   ScreenRetrieverWindowsPluginCApiRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("ScreenRetrieverWindowsPluginCApi"));
   UrlLauncherWindowsRegisterWithRegistrar(

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -5,12 +5,14 @@
 list(APPEND FLUTTER_PLUGIN_LIST
   app_links
   connectivity_plus
+  flutter_timezone
   screen_retriever_windows
   url_launcher_windows
   window_manager
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST
+  flutter_local_notifications_windows
 )
 
 set(PLUGIN_BUNDLED_LIBRARIES)


### PR DESCRIPTION
Simplifies due-card notifications to schedule nearest distinct due dates only, triggered on app launch and end of study session. This removes per-mutation rescheduling and keeps permission prompts tied to explicit user settings.