### PR TITLE
fix: sync reliability — realtime resubscribe and provider invalidation

### DIFF
--- a/lib/core/sync/sync_realtime_service.dart
+++ b/lib/core/sync/sync_realtime_service.dart
@@ -13,8 +13,15 @@ class SyncRealtimeService {
   final VoidCallback _onRemoteChange;
   Timer? _debounceTimer;
   RealtimeChannel? _channel;
+  bool _disposed = false;
+
+  /// Monotonically increasing counter so a newer [subscribe] call
+  /// silently cancels any in-flight retry from a previous call.
+  int _generation = 0;
 
   static const _debounceDelay = Duration(seconds: 2);
+  static const _maxAttempts = 3;
+  static const _subscribeTimeout = Duration(seconds: 10);
 
   SyncRealtimeService({
     required SupabaseClient client,
@@ -23,23 +30,57 @@ class SyncRealtimeService {
        _onRemoteChange = onRemoteChange;
 
   /// Subscribes to the user's private sync broadcast channel.
-  void subscribe(String userId) {
-    unsubscribe();
+  ///
+  /// Retries with exponential backoff (1s, 2s, 4s) on failure. A newer
+  /// call to [subscribe] cancels any in-flight retry from a previous call.
+  Future<void> subscribe(String userId, {int attempt = 0, int? generation}) async {
+    final gen = generation ?? ++_generation;
+
+    // A newer subscribe() or dispose() was called — abandon this attempt.
+    if (gen != _generation || _disposed) return;
+
+    await unsubscribe();
+
+    if (_disposed) return;
 
     _channel = _client.channel(
       'user:$userId:sync',
       opts: const RealtimeChannelConfig(private: true),
     );
 
-    _channel!.onBroadcast(event: 'sync_change', callback: (_) => _onChange());
+    final completer = Completer<void>();
 
     _channel!.subscribe((status, [error]) {
+      if (completer.isCompleted) return;
       if (status == RealtimeSubscribeStatus.subscribed) {
-        debugPrint('[SyncRealtime] Subscribed to user:$userId:sync');
+        completer.complete();
       } else if (error != null) {
-        debugPrint('[SyncRealtime] Subscribe error: $error');
+        completer.completeError(error);
       }
     });
+
+    try {
+      await completer.future.timeout(_subscribeTimeout);
+
+      // Register broadcast listener AFTER subscription is confirmed.
+      if (gen != _generation || _disposed) return;
+      _channel?.onBroadcast(event: 'sync_change', callback: (_) => _onChange());
+      debugPrint('[SyncRealtime] Subscribed to user:$userId:sync');
+    } catch (e) {
+      debugPrint(
+        '[SyncRealtime] Subscribe attempt ${attempt + 1} failed: $e',
+      );
+
+      if (attempt + 1 < _maxAttempts && gen == _generation && !_disposed) {
+        final delay = Duration(seconds: 1 << attempt); // 1s, 2s, 4s
+        await Future.delayed(delay);
+        return subscribe(userId, attempt: attempt + 1, generation: gen);
+      }
+
+      debugPrint(
+        '[SyncRealtime] Giving up after ${attempt + 1} attempt(s)',
+      );
+    }
   }
 
   void _onChange() {
@@ -48,15 +89,18 @@ class SyncRealtimeService {
   }
 
   /// Unsubscribes from the channel and cancels any pending debounce.
-  void unsubscribe() {
+  Future<void> unsubscribe() async {
     _debounceTimer?.cancel();
     if (_channel != null) {
-      _client.removeChannel(_channel!);
+      final channel = _channel!;
       _channel = null;
+      await _client.removeChannel(channel);
     }
   }
 
   void dispose() {
+    _disposed = true;
+    _generation++; // Cancel any in-flight retries.
     unsubscribe();
   }
 }

--- a/lib/core/sync/sync_service.dart
+++ b/lib/core/sync/sync_service.dart
@@ -11,6 +11,9 @@ import 'sync_pull_service.dart';
 import 'sync_push_service.dart';
 import 'sync_realtime_service.dart';
 import 'sync_adapter.dart';
+import '../../features/cards/presentation/providers/card_browser_provider.dart';
+import '../../features/cards/presentation/providers/card_list_provider.dart';
+import '../../features/decks/presentation/providers/deck_detail_provider.dart';
 import '../../features/decks/presentation/providers/deck_list_provider.dart';
 
 /// Sync orchestrator state exposed to the UI.
@@ -284,8 +287,13 @@ class SyncServiceNotifier extends Notifier<SyncState> {
 
       if (ok) {
         state = state.copyWith(isSyncing: false, lastSyncTime: DateTime.now());
-        // Refresh the deck list so UI reflects any pulled changes.
+        // Refresh all data providers so UI reflects pulled changes.
+        // deckDetailProvider also rebuilds via its lastSyncTime watcher, but
+        // explicit invalidation prevents regressions if that watcher is removed.
         ref.invalidate(deckListProvider);
+        ref.invalidate(deckDetailProvider);
+        ref.invalidate(cardListProvider);
+        ref.invalidate(filteredCardsProvider);
         return SyncResult.success(message);
       } else {
         final errors = <String>[


### PR DESCRIPTION
## Summary
- Fix realtime channel resubscription race condition (#144): make subscribe/unsubscribe async, await channel teardown before creating new channel, register broadcast listener after subscription confirms, add retry with exponential backoff (3 attempts), add generation counter to cancel stale retries
- Invalidate all data providers (deckDetail, cardList, filteredCards) after successful sync pull (#44), not just deckListProvider — previously-visited decks now reflect remote changes without a restart

Closes #144, closes #44