### PR TITLE
fix(notifications): keep due reminders in sync after due-date mutations

### DIFF
--- a/lib/core/sync/sync_service.dart
+++ b/lib/core/sync/sync_service.dart
@@ -15,6 +15,7 @@ import '../../features/cards/presentation/providers/card_browser_provider.dart';
 import '../../features/cards/presentation/providers/card_list_provider.dart';
 import '../../features/decks/presentation/providers/deck_detail_provider.dart';
 import '../../features/decks/presentation/providers/deck_list_provider.dart';
+import '../../features/notifications/presentation/providers/notification_providers.dart';
 
 /// Sync orchestrator state exposed to the UI.
 class SyncState {
@@ -277,6 +278,9 @@ class SyncServiceNotifier extends Notifier<SyncState> {
 
       final pushResult = await _pushService.pushWithDetail();
       final pullResult = await _pullService.pullWithDetail();
+      if (pullResult.ok) {
+        unawaited(ref.read(dueReminderSchedulerProvider).syncSchedule());
+      }
 
       final ok = pushResult.ok && pullResult.ok;
       final parts = <String>[

--- a/lib/features/cards/presentation/providers/card_list_provider.dart
+++ b/lib/features/cards/presentation/providers/card_list_provider.dart
@@ -28,6 +28,7 @@ class CardListNotifier extends AsyncNotifier<List<Flashcard>> {
     });
     ref.invalidate(deckListProvider);
     ref.read(syncServiceProvider.notifier).schedulePush();
+    unawaited(ref.read(dueReminderSchedulerProvider).syncSchedule());
   }
 
   Future<void> updateCard(Flashcard card) async {
@@ -37,6 +38,7 @@ class CardListNotifier extends AsyncNotifier<List<Flashcard>> {
     });
     ref.invalidate(deckListProvider);
     ref.read(syncServiceProvider.notifier).schedulePush();
+    unawaited(ref.read(dueReminderSchedulerProvider).syncSchedule());
   }
 
   Future<void> deleteCard(String cardId) async {

--- a/lib/features/cards/presentation/providers/card_list_provider.dart
+++ b/lib/features/cards/presentation/providers/card_list_provider.dart
@@ -1,8 +1,11 @@
+import 'dart:async';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lapse/core/sync/sync_service.dart';
 import 'package:lapse/features/cards/data/card_repository_provider.dart';
 import 'package:lapse/features/cards/domain/flashcard.dart';
 import 'package:lapse/features/decks/presentation/providers/deck_list_provider.dart';
+import 'package:lapse/features/notifications/presentation/providers/notification_providers.dart';
 
 final cardListProvider =
     AsyncNotifierProvider.family<CardListNotifier, List<Flashcard>, String>(
@@ -43,5 +46,6 @@ class CardListNotifier extends AsyncNotifier<List<Flashcard>> {
     });
     ref.invalidate(deckListProvider);
     ref.read(syncServiceProvider.notifier).schedulePush();
+    unawaited(ref.read(dueReminderSchedulerProvider).syncSchedule());
   }
 }

--- a/lib/features/cards/presentation/screens/card_form_screen.dart
+++ b/lib/features/cards/presentation/screens/card_form_screen.dart
@@ -138,6 +138,7 @@ class _CardFormScreenState extends ConsumerState<CardFormScreen> {
       ref.invalidate(deckDetailProvider(widget.deckId));
       ref.invalidate(deckListProvider);
       ref.read(syncServiceProvider.notifier).schedulePush();
+      unawaited(ref.read(dueReminderSchedulerProvider).syncSchedule());
       if (mounted) {
         final label = widget.isEditing
             ? 'Card updated'
@@ -168,6 +169,7 @@ class _CardFormScreenState extends ConsumerState<CardFormScreen> {
       ref.invalidate(deckDetailProvider(widget.deckId));
       ref.invalidate(deckListProvider);
       ref.read(syncServiceProvider.notifier).schedulePush();
+      unawaited(ref.read(dueReminderSchedulerProvider).syncSchedule());
 
       if (mounted) {
         setState(() {

--- a/lib/features/cards/presentation/screens/card_form_screen.dart
+++ b/lib/features/cards/presentation/screens/card_form_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_markdown_plus/flutter_markdown_plus.dart';
@@ -14,6 +16,7 @@ import 'package:lapse/features/cards/data/card_repository_provider.dart';
 import 'package:lapse/features/cards/domain/flashcard.dart';
 import 'package:lapse/features/decks/presentation/providers/deck_detail_provider.dart';
 import 'package:lapse/features/decks/presentation/providers/deck_list_provider.dart';
+import 'package:lapse/features/notifications/presentation/providers/notification_providers.dart';
 
 class _SaveIntent extends Intent {
   const _SaveIntent();
@@ -196,6 +199,7 @@ class _CardFormScreenState extends ConsumerState<CardFormScreen> {
     ref.invalidate(deckDetailProvider(widget.deckId));
     ref.invalidate(deckListProvider);
     ref.read(syncServiceProvider.notifier).schedulePush();
+    unawaited(ref.read(dueReminderSchedulerProvider).syncSchedule());
     if (mounted) context.pop();
   }
 

--- a/lib/features/decks/presentation/providers/deck_detail_provider.dart
+++ b/lib/features/decks/presentation/providers/deck_detail_provider.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lapse/core/sync/sync_service.dart';
 import 'package:lapse/features/cards/data/card_repository_provider.dart';
@@ -5,6 +7,7 @@ import 'package:lapse/features/decks/data/deck_repository_provider.dart';
 import 'package:lapse/features/decks/domain/deck.dart';
 import 'package:lapse/features/decks/presentation/providers/deck_detail_state.dart';
 import 'package:lapse/features/decks/presentation/providers/deck_list_provider.dart';
+import 'package:lapse/features/notifications/presentation/providers/notification_providers.dart';
 
 const int _cardPageSize = 50;
 
@@ -127,6 +130,7 @@ class DeckDetailNotifier extends AsyncNotifier<DeckDetailState> {
   Future<void> deleteCard(String cardId) async {
     await ref.read(cardRepositoryProvider).delete(cardId);
     ref.invalidate(deckListProvider);
+    unawaited(ref.read(dueReminderSchedulerProvider).syncSchedule());
 
     final current = state.asData?.value;
     if (current == null) return;

--- a/lib/features/decks/presentation/providers/deck_detail_provider.dart
+++ b/lib/features/decks/presentation/providers/deck_detail_provider.dart
@@ -98,6 +98,7 @@ class DeckDetailNotifier extends AsyncNotifier<DeckDetailState> {
     await ref.read(deckRepositoryProvider).delete(childDeckId);
     ref.invalidateSelf();
     ref.invalidate(deckListProvider);
+    unawaited(ref.read(dueReminderSchedulerProvider).syncSchedule());
   }
 
   Future<void> moveChildDeck(String childDeckId, String? newParentId) async {

--- a/lib/features/decks/presentation/providers/deck_list_provider.dart
+++ b/lib/features/decks/presentation/providers/deck_list_provider.dart
@@ -1,8 +1,11 @@
+import 'dart:async';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lapse/core/sync/sync_service.dart';
 import 'package:lapse/features/decks/data/deck_repository_provider.dart';
 import 'package:lapse/features/decks/domain/deck.dart';
 import 'package:lapse/features/decks/domain/deck_with_counts.dart';
+import 'package:lapse/features/notifications/presentation/providers/notification_providers.dart';
 
 final deckListProvider =
     AsyncNotifierProvider<DeckListNotifier, List<DeckWithCounts>>(
@@ -35,5 +38,6 @@ class DeckListNotifier extends AsyncNotifier<List<DeckWithCounts>> {
     await repo.delete(deckId);
     ref.invalidateSelf();
     ref.read(syncServiceProvider.notifier).schedulePush();
+    unawaited(ref.read(dueReminderSchedulerProvider).syncSchedule());
   }
 }

--- a/lib/features/decks/presentation/screens/deck_detail_screen.dart
+++ b/lib/features/decks/presentation/screens/deck_detail_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -19,6 +21,7 @@ import 'package:lapse/features/decks/presentation/providers/deck_detail_provider
 import 'package:lapse/features/decks/presentation/providers/deck_detail_state.dart';
 import 'package:lapse/features/decks/presentation/providers/deck_list_provider.dart';
 import 'package:lapse/features/decks/presentation/widgets/deck_card.dart';
+import 'package:lapse/features/notifications/presentation/providers/notification_providers.dart';
 
 class DeckDetailScreen extends ConsumerStatefulWidget {
   final String deckId;
@@ -163,6 +166,7 @@ class _DeckDetailScreenState extends ConsumerState<DeckDetailScreen>
     if (!confirmed || !mounted) return;
     await ref.read(deckRepositoryProvider).delete(widget.deckId);
     ref.invalidate(deckListProvider);
+    unawaited(ref.read(dueReminderSchedulerProvider).syncSchedule());
     if (!mounted) return;
     if (detail.ancestors.isNotEmpty) {
       _navigateWithAncestorStack(

--- a/lib/features/decks/presentation/screens/deck_form_screen.dart
+++ b/lib/features/decks/presentation/screens/deck_form_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -12,6 +14,7 @@ import 'package:lapse/features/decks/data/deck_repository_provider.dart';
 import 'package:lapse/features/decks/domain/deck.dart';
 import 'package:lapse/features/decks/presentation/providers/deck_detail_provider.dart';
 import 'package:lapse/features/decks/presentation/providers/deck_list_provider.dart';
+import 'package:lapse/features/notifications/presentation/providers/notification_providers.dart';
 
 class DeckFormScreen extends ConsumerStatefulWidget {
   final Deck? deck;
@@ -98,6 +101,7 @@ class _DeckFormScreenState extends ConsumerState<DeckFormScreen> {
     await _repo.delete(widget.deck!.deckId);
     ref.invalidate(deckListProvider);
     ref.read(syncServiceProvider.notifier).schedulePush();
+    unawaited(ref.read(dueReminderSchedulerProvider).syncSchedule());
     if (mounted) context.go(Routes.home);
   }
 

--- a/lib/features/notifications/application/due_reminder_scheduler.dart
+++ b/lib/features/notifications/application/due_reminder_scheduler.dart
@@ -1,6 +1,7 @@
 import 'package:lapse/features/notifications/data/notification_prefs_store.dart';
 import 'package:lapse/features/notifications/application/notification_service.dart';
 import 'package:lapse/features/cards/data/card_repository.dart';
+import 'package:lapse/features/notifications/domain/notification_settings.dart';
 
 class DueReminderScheduler {
   static const int maxScheduledReminders = 30;
@@ -30,9 +31,76 @@ class DueReminderScheduler {
 
     if (!settings.enabled) return;
 
+    final plans = await _buildDesiredPlans(settings);
+    if (plans.isEmpty) return;
+
+    final scheduledIds = <int>[];
+    for (final plan in plans.take(maxScheduledReminders)) {
+      await _notificationService.scheduleDueReminder(
+        id: plan.id,
+        title: plan.title,
+        body: plan.body,
+        whenLocal: plan.fireAt,
+      );
+      scheduledIds.add(plan.id);
+    }
+
+    await _prefsStore.saveScheduledDueReminderIds(scheduledIds);
+  }
+
+  /// Incrementally syncs scheduled reminder IDs to current due dates by
+  /// canceling/scheduling only the delta.
+  Future<void> syncSchedule() async {
+    await _notificationService.initialize();
+
+    final settings = await _prefsStore.load();
+    final existingIds = (await _prefsStore.loadScheduledDueReminderIds())
+        .toSet();
+
+    if (!settings.enabled) {
+      if (existingIds.isNotEmpty) {
+        await _notificationService.cancelDueReminders(existingIds);
+      }
+      await _prefsStore.saveScheduledDueReminderIds(const <int>[]);
+      return;
+    }
+
+    final desiredPlans = (await _buildDesiredPlans(settings))
+        .take(maxScheduledReminders)
+        .toList(growable: false);
+    final desiredIds = desiredPlans.map((p) => p.id).toSet();
+
+    final toCancel = existingIds.difference(desiredIds);
+    if (toCancel.isNotEmpty) {
+      await _notificationService.cancelDueReminders(toCancel);
+    }
+
+    final planById = <int, _ReminderPlan>{
+      for (final plan in desiredPlans) plan.id: plan,
+    };
+    final toAdd = desiredIds.difference(existingIds);
+    for (final id in toAdd) {
+      final plan = planById[id];
+      if (plan == null) continue;
+      await _notificationService.scheduleDueReminder(
+        id: plan.id,
+        title: plan.title,
+        body: plan.body,
+        whenLocal: plan.fireAt,
+      );
+    }
+
+    await _prefsStore.saveScheduledDueReminderIds(
+      desiredPlans.map((p) => p.id).toList(),
+    );
+  }
+
+  Future<List<_ReminderPlan>> _buildDesiredPlans(
+    NotificationSettings settings,
+  ) async {
     final now = _now();
     final sortedDays = await _cardRepository.getDistinctDueDates();
-    if (sortedDays.isEmpty) return;
+    if (sortedDays.isEmpty) return const <_ReminderPlan>[];
 
     sortedDays.sort((a, b) => a.compareTo(b));
 
@@ -56,21 +124,8 @@ class DueReminderScheduler {
         ),
       );
     }
-
     plans.sort((a, b) => a.fireAt.compareTo(b.fireAt));
-
-    final scheduledIds = <int>[];
-    for (final plan in plans.take(maxScheduledReminders)) {
-      await _notificationService.scheduleDueReminder(
-        id: plan.id,
-        title: plan.title,
-        body: plan.body,
-        whenLocal: plan.fireAt,
-      );
-      scheduledIds.add(plan.id);
-    }
-
-    await _prefsStore.saveScheduledDueReminderIds(scheduledIds);
+    return plans;
   }
 
   static int _notificationId(DateTime day) {

--- a/lib/features/study/presentation/screens/study_session_screen.dart
+++ b/lib/features/study/presentation/screens/study_session_screen.dart
@@ -889,7 +889,7 @@ class _StudySessionScreenState extends ConsumerState<StudySessionScreen>
               onPressed: () async {
                 await _flushPendingWrite();
                 _invalidateDeckProviders();
-                unawaited(ref.read(dueReminderSchedulerProvider).rescheduleAll());
+                unawaited(ref.read(dueReminderSchedulerProvider).syncSchedule());
                 if (mounted) context.pop();
               },
               child: const Text('Done'),
@@ -951,7 +951,7 @@ class _StudySessionScreenState extends ConsumerState<StudySessionScreen>
     if (shouldExit == true && context.mounted) {
       await _flushPendingWrite();
       _invalidateDeckProviders();
-      unawaited(ref.read(dueReminderSchedulerProvider).rescheduleAll());
+      unawaited(ref.read(dueReminderSchedulerProvider).syncSchedule());
       if (context.mounted) context.pop();
     }
   }

--- a/test/features/notifications/application/due_reminder_scheduler_test.dart
+++ b/test/features/notifications/application/due_reminder_scheduler_test.dart
@@ -1,0 +1,129 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lapse/features/cards/data/card_repository.dart';
+import 'package:lapse/features/notifications/application/due_reminder_scheduler.dart';
+import 'package:lapse/features/notifications/application/notification_service.dart';
+import 'package:lapse/features/notifications/data/notification_prefs_store.dart';
+import 'package:lapse/features/notifications/domain/notification_settings.dart';
+
+void main() {
+  int idFor(DateTime day) => day.year * 10000 + day.month * 100 + day.day;
+
+  group('syncSchedule', () {
+    test('cancels and schedules only the delta', () async {
+      final day17 = DateTime(2026, 4, 17);
+      final day18 = DateTime(2026, 4, 18);
+      final day19 = DateTime(2026, 4, 19);
+
+      final cardRepo = _FakeCardRepository([day17, day18]);
+      final notifications = _FakeNotificationService();
+      final prefs = _FakePrefsStore(
+        settings: const NotificationSettings(
+          enabled: true,
+          remindDueToday: true,
+          remindOneDayBefore: true,
+          remindOneWeekBefore: true,
+          reminderHour: 9,
+          reminderMinute: 0,
+        ),
+        scheduledIds: [idFor(day17), idFor(day19)],
+      );
+
+      final scheduler = DueReminderScheduler(
+        cardRepository: cardRepo,
+        notificationService: notifications,
+        prefsStore: prefs,
+        now: () => DateTime(2026, 4, 16, 8, 0),
+      );
+
+      await scheduler.syncSchedule();
+
+      expect(notifications.canceledIds, [idFor(day19)]);
+      expect(notifications.scheduledIds, [idFor(day18)]);
+      expect(prefs.scheduledIds, [idFor(day17), idFor(day18)]);
+    });
+
+    test('disabling reminders clears existing scheduled IDs', () async {
+      final day17 = DateTime(2026, 4, 17);
+      final day18 = DateTime(2026, 4, 18);
+      final notifications = _FakeNotificationService();
+      final prefs = _FakePrefsStore(
+        settings: const NotificationSettings(
+          enabled: false,
+          remindDueToday: true,
+          remindOneDayBefore: true,
+          remindOneWeekBefore: true,
+          reminderHour: 9,
+          reminderMinute: 0,
+        ),
+        scheduledIds: [idFor(day17), idFor(day18)],
+      );
+
+      final scheduler = DueReminderScheduler(
+        cardRepository: _FakeCardRepository([day17, day18]),
+        notificationService: notifications,
+        prefsStore: prefs,
+        now: () => DateTime(2026, 4, 16, 8, 0),
+      );
+
+      await scheduler.syncSchedule();
+
+      expect(notifications.canceledIds, [idFor(day17), idFor(day18)]);
+      expect(prefs.scheduledIds, isEmpty);
+    });
+  });
+}
+
+class _FakeCardRepository extends CardRepository {
+  final List<DateTime> dueDays;
+
+  _FakeCardRepository(this.dueDays);
+
+  @override
+  Future<List<DateTime>> getDistinctDueDates() async => dueDays;
+}
+
+class _FakeNotificationService extends NotificationService {
+  final List<int> canceledIds = <int>[];
+  final List<int> scheduledIds = <int>[];
+
+  @override
+  Future<void> initialize() async {}
+
+  @override
+  Future<void> cancelDueReminders(Iterable<int> ids) async {
+    canceledIds.addAll(ids);
+  }
+
+  @override
+  Future<void> scheduleDueReminder({
+    required int id,
+    required String title,
+    required String body,
+    required DateTime whenLocal,
+  }) async {
+    scheduledIds.add(id);
+  }
+}
+
+class _FakePrefsStore extends NotificationPrefsStore {
+  NotificationSettings settings;
+  List<int> scheduledIds;
+
+  _FakePrefsStore({required this.settings, required this.scheduledIds});
+
+  @override
+  Future<NotificationSettings> load() async => settings;
+
+  @override
+  Future<List<int>> loadScheduledDueReminderIds() async => scheduledIds;
+
+  @override
+  Future<void> saveScheduledDueReminderIds(List<int> ids) async {
+    scheduledIds = List<int>.from(ids);
+  }
+
+  @override
+  Future<void> save(NotificationSettings settings) async {
+    this.settings = settings;
+  }
+}


### PR DESCRIPTION
Adds incremental reminder syncing at due-date mutation points using fire-and-forget syncSchedule() so scheduled reminder IDs stay aligned with distinct due dates, while preserving full rescheduleAll() for app launch and notification settings changes. refs: #175